### PR TITLE
CI: cap .deb artifact retention at 7 days

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -71,3 +71,7 @@ jobs:
           path: |
             artifacts/*.deb
             artifacts/*.ddeb
+          # 7-day retention so build artifacts don't pile up against the
+          # account-level Actions storage quota. Long enough to grab a
+          # .deb off a recent commit; older commits should be rebuilt.
+          retention-days: 7


### PR DESCRIPTION
The `Upload .deb artifact` step in `build-deb.yml` was using GHA's
default 90-day retention. Each push uploads packages on both `amd64`
and `arm64` and includes `.deb` + `.ddeb` (debug symbol) packages,
so artifacts accumulate fast against the account-level Actions
storage quota.

Adds `retention-days: 7`. Same pattern as conops and creature-listener.

7 days is enough to grab a package off a recent commit; older commits
should be rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)