### PR TITLE
CLI database tooling: migrate-database + backfill (2.28.0)

### DIFF
--- a/Common/Package.swift
+++ b/Common/Package.swift
@@ -32,6 +32,7 @@ let package = Package(
             from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.4.0"),
+        .package(url: "https://github.com/orlandos-nl/MongoKitten.git", from: "7.16.0"),
     ],
 
     targets: [
@@ -93,6 +94,7 @@ let package = Package(
                 "Common",
                 "Observability",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "MongoKitten", package: "MongoKitten"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
                 .product(
                     name: "NIOCore",

--- a/Common/Package.swift
+++ b/Common/Package.swift
@@ -88,10 +88,21 @@ let package = Package(
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
             ]),
 
+        // MongoDB migration/back-fill building blocks (server-address parsing, connection
+        // helper, content-reference extraction). Kept out of Common so MongoKitten doesn't
+        // leak into the GUI app; the CLI commands depend on this.
+        .target(
+            name: "CreatureMigration",
+            dependencies: [
+                .product(name: "MongoKitten", package: "MongoKitten")
+            ],
+            path: "Sources/CreatureMigration/"),
+
         .executableTarget(
             name: "creature-cli",
             dependencies: [
                 "Common",
+                "CreatureMigration",
                 "Observability",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "MongoKitten", package: "MongoKitten"),
@@ -136,6 +147,8 @@ let package = Package(
             dependencies: [
                 "Common",
                 "creature-cli",
+                "CreatureMigration",
+                .product(name: "MongoKitten", package: "MongoKitten"),
             ]
         ),
         .testTarget(

--- a/Common/Sources/CreatureAgent/runCommand.swift
+++ b/Common/Sources/CreatureAgent/runCommand.swift
@@ -38,8 +38,8 @@ extension CreatureAgent {
         var traceOpenAI: Bool = false
 
         @Flag(
-            name: .customLong("trace-open-ai"),
-            help: "Log OpenAI response bodies for debugging")
+            name: .customLong("trace-openai"),
+            help: "Alias for --trace-open-ai")
         var traceOpenAICompat: Bool = false
 
         @OptionGroup()

--- a/Common/Sources/CreatureAgent/top.swift
+++ b/Common/Sources/CreatureAgent/top.swift
@@ -32,7 +32,7 @@ struct CreatureAgent: AsyncParsableCommand {
         abstract: "Listen to MQTT, generate LLM responses, schedule ad-hoc speech",
         discussion:
             "Consumes MQTT topics and uses an LLM backend (OpenAI or local) to generate ad-hoc speech animations on the Creature server.",
-        version: "2.26.1",
+        version: "2.28.0",
         subcommands: [Run.self],
         defaultSubcommand: Run.self,
         helpNames: .shortAndLong

--- a/Common/Sources/CreatureCLI/MongoServerAddress.swift
+++ b/Common/Sources/CreatureCLI/MongoServerAddress.swift
@@ -10,6 +10,10 @@ enum MongoServerAddress {
 
     static let defaultPort = 27017
 
+    /// Connect timeout baked into URIs we build from bare hostnames, so a wrong address
+    /// fails in seconds instead of MongoKitten's five-minute default.
+    static let connectTimeoutMS = 5000
+
     enum AddressError: Error, LocalizedError, Equatable {
         case emptyAddress
         case unsupportedScheme(String)
@@ -32,7 +36,13 @@ enum MongoServerAddress {
     }
 
     /// Builds a MongoDB connection URI for the given server address and database.
-    static func connectionURI(for server: String, database: String) throws -> String {
+    ///
+    /// `port` is used when the address itself doesn't carry one; an explicit port in the
+    /// address (`host:27018`) wins. Full `mongodb://` URIs are the user's business and are
+    /// passed through untouched apart from getting the database path filled in.
+    static func connectionURI(
+        for server: String, database: String, port: Int = defaultPort
+    ) throws -> String {
         let trimmed = server.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             throw AddressError.emptyAddress
@@ -46,8 +56,9 @@ enum MongoServerAddress {
             return ensureDatabase(in: trimmed, after: schemeRange.upperBound, database: database)
         }
 
-        let hostAndPort = try normalizeHostAndPort(trimmed)
-        return "mongodb://\(hostAndPort)/\(database)"
+        let fallbackPort = try validatedPort(String(port))
+        let hostAndPort = try normalizeHostAndPort(trimmed, fallbackPort: fallbackPort)
+        return "mongodb://\(hostAndPort)/\(database)?connectTimeoutMS=\(connectTimeoutMS)"
     }
 
     /// Inserts the database name into a full URI's path if the URI doesn't already have one,
@@ -75,7 +86,9 @@ enum MongoServerAddress {
 
     /// Normalizes a bare `host`, `host:port`, `ipv6`, or `[ipv6]:port` value into
     /// a `host:port` authority string suitable for a mongodb:// URI.
-    private static func normalizeHostAndPort(_ address: String) throws -> String {
+    private static func normalizeHostAndPort(
+        _ address: String, fallbackPort: Int
+    ) throws -> String {
         // Bracketed IPv6, possibly with a port: [::1] or [::1]:27017
         if address.hasPrefix("[") {
             guard let closingBracket = address.firstIndex(of: "]") else {
@@ -84,7 +97,7 @@ enum MongoServerAddress {
             let host = String(address[...closingBracket])
             let remainder = address[address.index(after: closingBracket)...]
             if remainder.isEmpty {
-                return "\(host):\(defaultPort)"
+                return "\(host):\(fallbackPort)"
             }
             guard remainder.hasPrefix(":") else {
                 throw AddressError.invalidAddress(address)
@@ -97,7 +110,7 @@ enum MongoServerAddress {
 
         // More than one colon and no brackets means a bare IPv6 literal like ::1
         if colonCount > 1 {
-            return "[\(address)]:\(defaultPort)"
+            return "[\(address)]:\(fallbackPort)"
         }
 
         if colonCount == 1 {
@@ -109,7 +122,7 @@ enum MongoServerAddress {
             return "\(parts[0]):\(port)"
         }
 
-        return "\(address):\(defaultPort)"
+        return "\(address):\(fallbackPort)"
     }
 
     private static func validatedPort(_ value: String) throws -> Int {

--- a/Common/Sources/CreatureCLI/MongoServerAddress.swift
+++ b/Common/Sources/CreatureCLI/MongoServerAddress.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Normalizes user-supplied MongoDB server addresses into full connection URIs.
+///
+/// Accepts a bare hostname or IP (`travel.local`, `10.3.2.11`), a host with a port
+/// (`travel.local:27018`), an IPv6 literal (`::1` or `[::1]:27017`), or a complete
+/// `mongodb://` / `mongodb+srv://` URI. The result always carries a database name in
+/// its path so MongoKitten connects to the right database.
+enum MongoServerAddress {
+
+    static let defaultPort = 27017
+
+    enum AddressError: Error, LocalizedError, Equatable {
+        case emptyAddress
+        case unsupportedScheme(String)
+        case invalidPort(String)
+        case invalidAddress(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .emptyAddress:
+                return "Server address is empty"
+            case .unsupportedScheme(let scheme):
+                return
+                    "Unsupported URI scheme '\(scheme)' — use mongodb:// or mongodb+srv://, or just a hostname"
+            case .invalidPort(let port):
+                return "'\(port)' is not a valid port number"
+            case .invalidAddress(let address):
+                return "'\(address)' is not a valid server address"
+            }
+        }
+    }
+
+    /// Builds a MongoDB connection URI for the given server address and database.
+    static func connectionURI(for server: String, database: String) throws -> String {
+        let trimmed = server.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw AddressError.emptyAddress
+        }
+
+        if let schemeRange = trimmed.range(of: "://") {
+            let scheme = String(trimmed[..<schemeRange.lowerBound])
+            guard scheme == "mongodb" || scheme == "mongodb+srv" else {
+                throw AddressError.unsupportedScheme(scheme)
+            }
+            return ensureDatabase(in: trimmed, after: schemeRange.upperBound, database: database)
+        }
+
+        let hostAndPort = try normalizeHostAndPort(trimmed)
+        return "mongodb://\(hostAndPort)/\(database)"
+    }
+
+    /// Inserts the database name into a full URI's path if the URI doesn't already have one,
+    /// preserving any query string (e.g. `?authSource=admin`).
+    private static func ensureDatabase(
+        in uri: String, after authorityStart: String.Index, database: String
+    ) -> String {
+        let afterScheme = uri[authorityStart...]
+
+        let queryStart = afterScheme.firstIndex(of: "?")
+        let mainPart = queryStart.map { afterScheme[..<$0] } ?? afterScheme
+        let query = queryStart.map { String(afterScheme[$0...]) } ?? ""
+        let prefix = String(uri[..<authorityStart])
+
+        if let slash = mainPart.firstIndex(of: "/") {
+            let path = mainPart[mainPart.index(after: slash)...]
+            if path.isEmpty {
+                return "\(prefix)\(mainPart)\(database)\(query)"
+            }
+            return uri
+        }
+
+        return "\(prefix)\(mainPart)/\(database)\(query)"
+    }
+
+    /// Normalizes a bare `host`, `host:port`, `ipv6`, or `[ipv6]:port` value into
+    /// a `host:port` authority string suitable for a mongodb:// URI.
+    private static func normalizeHostAndPort(_ address: String) throws -> String {
+        // Bracketed IPv6, possibly with a port: [::1] or [::1]:27017
+        if address.hasPrefix("[") {
+            guard let closingBracket = address.firstIndex(of: "]") else {
+                throw AddressError.invalidAddress(address)
+            }
+            let host = String(address[...closingBracket])
+            let remainder = address[address.index(after: closingBracket)...]
+            if remainder.isEmpty {
+                return "\(host):\(defaultPort)"
+            }
+            guard remainder.hasPrefix(":") else {
+                throw AddressError.invalidAddress(address)
+            }
+            let port = try validatedPort(String(remainder.dropFirst()))
+            return "\(host):\(port)"
+        }
+
+        let colonCount = address.filter { $0 == ":" }.count
+
+        // More than one colon and no brackets means a bare IPv6 literal like ::1
+        if colonCount > 1 {
+            return "[\(address)]:\(defaultPort)"
+        }
+
+        if colonCount == 1 {
+            let parts = address.split(separator: ":", maxSplits: 1)
+            guard parts.count == 2 else {
+                throw AddressError.invalidAddress(address)
+            }
+            let port = try validatedPort(String(parts[1]))
+            return "\(parts[0]):\(port)"
+        }
+
+        return "\(address):\(defaultPort)"
+    }
+
+    private static func validatedPort(_ value: String) throws -> Int {
+        guard let port = Int(value), (1...65535).contains(port) else {
+            throw AddressError.invalidPort(value)
+        }
+        return port
+    }
+}

--- a/Common/Sources/CreatureCLI/backfillCommand.swift
+++ b/Common/Sources/CreatureCLI/backfillCommand.swift
@@ -1,0 +1,581 @@
+import ArgumentParser
+import Common
+import CreatureMigration
+import Foundation
+import MongoKitten
+
+extension CreatureCLI.Util {
+
+    struct Backfill: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "backfill",
+            abstract:
+                "Copy road-created animations, dialog scripts, and storyboards from the travel server back into the mainline server",
+            discussion: """
+                The reverse of migrate-database, scoped to the content you create on the road: \
+                animations, dialog scripts, and storyboards. Entities are matched by their UUID \
+                `id` (the Mongo `_id` is ignored).
+
+                By default this is add-only — only items whose id is missing from the mainline \
+                server are copied, and existing mainline documents are never modified. Pass \
+                --update-existing to also overwrite items that already exist.
+
+                Dialog scripts reference the creatures that speak their turns, and storyboards \
+                reference animations, creatures, fixtures, playlists, and dialog scripts. Before \
+                copying an item whose references are missing on the mainline server, you are \
+                prompted to copy it anyway, pull the missing items across too, skip it, or abort. \
+                With --yes, items that have missing references are skipped (run interactively to \
+                decide per item).
+
+                After writing, the mainline creature-server is told to invalidate the caches \
+                for the collections that changed (so connected consoles re-pull the data). \
+                That call goes to the server named by the global --host/--port options — point \
+                them at the mainline creature-server. Use --skip-cache-invalidation to disable.
+
+                Servers may be given as a hostname or IP (the default port \
+                \(MongoServerAddress.defaultPort) is assumed), host:port, or a full mongodb:// URI.
+                """
+        )
+
+        @Option(help: "Hostname or IP of the mainline (destination) MongoDB server")
+        var mainlineServer: String
+
+        @Option(help: "Port of the mainline MongoDB server")
+        var mainlinePort: Int = MongoServerAddress.defaultPort
+
+        @Option(help: "Hostname or IP of the travel (source) MongoDB server")
+        var travelServer: String
+
+        @Option(help: "Port of the travel MongoDB server")
+        var travelPort: Int = MongoServerAddress.defaultPort
+
+        @Option(help: "Name of the database")
+        var database: String = "creature_server"
+
+        @Flag(help: "Also overwrite items that already exist on the mainline server")
+        var updateExisting: Bool = false
+
+        @Flag(help: "Show what would be copied without writing anything")
+        var dryRun: Bool = false
+
+        @Flag(
+            name: [.customLong("yes"), .customShort("y")],
+            help: "Skip prompts; items with missing references are skipped")
+        var assumeYes: Bool = false
+
+        @Flag(help: "Don't tell the mainline server to invalidate its caches afterward")
+        var skipCacheInvalidation: Bool = false
+
+        @OptionGroup()
+        var globalOptions: GlobalOptions
+
+        func run() async throws {
+            // The cache-invalidation call goes to the mainline creature-server's HTTP API,
+            // which is configured by the global --host/--port options (not the Mongo host).
+            let server = getServer(config: globalOptions)
+            let plan = BackfillPlan(
+                mainlineServer: mainlineServer,
+                mainlinePort: mainlinePort,
+                travelServer: travelServer,
+                travelPort: travelPort,
+                database: database,
+                updateExisting: updateExisting,
+                dryRun: dryRun,
+                assumeYes: assumeYes,
+                skipCacheInvalidation: skipCacheInvalidation,
+                server: server
+            )
+            try await tracedRun("util.backfill", config: globalOptions) {
+                try await plan.execute()
+            }
+        }
+    }
+}
+
+/// Copies road-created content from the travel server back into the mainline server,
+/// matching on the UUID `id` and resolving each item's references first.
+private struct BackfillPlan: Sendable {
+    let mainlineServer: String
+    let mainlinePort: Int
+    let travelServer: String
+    let travelPort: Int
+    let database: String
+    let updateExisting: Bool
+    let dryRun: Bool
+    let assumeYes: Bool
+    let skipCacheInvalidation: Bool
+    let server: CreatureServerClient
+
+    /// Reference collections content can point at that live in the database.
+    /// (Sounds are referenced by file name and live on disk, so they're not here.)
+    private static let referenceCollections = [
+        "animations", "creatures", "playlists", "dialog_scripts", "fixtures",
+    ]
+
+    /// A travel document selected for back-fill.
+    private struct PlannedDoc {
+        let uuid: String
+        let title: String
+        let document: Document
+        let isNew: Bool
+    }
+
+    /// A reference that is missing on the mainline server.
+    private struct MissingDependency {
+        let reference: EntityReference
+        let name: String?
+        let sourceDocument: Document?
+        var canCopy: Bool { sourceDocument != nil }
+    }
+
+    /// A planned item plus the analysis of its references.
+    private struct ContentAnalysis {
+        let doc: PlannedDoc
+        let missing: [MissingDependency]
+        let unverifiableSounds: [String]
+    }
+
+    /// Tally of what one collection's apply step did.
+    private struct ApplyResult {
+        var added = 0
+        var updated = 0
+        var skipped = 0
+        var dependenciesCopied = 0
+    }
+
+    private enum MissingChoice {
+        case copyAnyway
+        case copyDeps
+        case skip
+        case abort
+    }
+
+    func execute() async throws {
+        // travel is the source (where road content was made); mainline is the destination.
+        let source = try await connectCreatureDatabase(
+            server: travelServer, port: travelPort, database: database, role: "travel")
+        let destination = try await connectCreatureDatabase(
+            server: mainlineServer, port: mainlinePort, database: database, role: "mainline")
+
+        // Plan each back-filled collection.
+        let plannedAnimations = try await planCollection(
+            "animations", from: source, to: destination, titleProvider: animationTitle)
+        let plannedDialogScripts = try await planCollection(
+            "dialog_scripts", from: source, to: destination, titleProvider: titleField)
+        let plannedStoryboards = try await planCollection(
+            "storyboards", from: source, to: destination, titleProvider: titleField)
+
+        // UUID sets that will exist on the destination after this run, used for reference
+        // checks — so an item that points at an animation or dialog script we're also
+        // copying in this run isn't flagged as missing.
+        var destinationIds: [String: Set<String>] = [:]
+        for collection in Self.referenceCollections {
+            destinationIds[collection] = try await uuidSet(of: collection, in: destination)
+        }
+        destinationIds["animations", default: []].formUnion(plannedAnimations.map(\.uuid))
+        destinationIds["dialog_scripts", default: []].formUnion(plannedDialogScripts.map(\.uuid))
+
+        let dialogAnalyses = try await analyzeReferences(
+            plannedDialogScripts, collection: "dialog_scripts", source: source,
+            destinationIds: destinationIds)
+        let storyboardAnalyses = try await analyzeReferences(
+            plannedStoryboards, collection: "storyboards", source: source,
+            destinationIds: destinationIds)
+
+        printPreview(
+            animations: plannedAnimations, dialogScripts: dialogAnalyses,
+            storyboards: storyboardAnalyses)
+
+        if dryRun {
+            print("Dry run — nothing was copied.")
+            return
+        }
+        if plannedAnimations.isEmpty && dialogAnalyses.isEmpty && storyboardAnalyses.isEmpty {
+            print("Nothing to back-fill — the mainline server is already up to date.")
+            return
+        }
+
+        try confirmIfNeeded()
+
+        // Collections we actually wrote to, so we invalidate exactly those caches afterward.
+        var modifiedCollections = Set<String>()
+
+        // Plain content (no references) first, then reference-bearing content in dependency
+        // order: dialog scripts before storyboards, since storyboards can reference them.
+        let animationResult = try await applyPlain(
+            plannedAnimations, collection: "animations", into: destination,
+            modified: &modifiedCollections)
+        let dialogResult = try await applyReferenceBearing(
+            dialogAnalyses, collection: "dialog_scripts", into: destination,
+            modified: &modifiedCollections)
+        let storyboardResult = try await applyReferenceBearing(
+            storyboardAnalyses, collection: "storyboards", into: destination,
+            modified: &modifiedCollections)
+
+        printSummary(
+            animations: animationResult, dialogScripts: dialogResult, storyboards: storyboardResult)
+
+        await invalidateCaches(for: modifiedCollections)
+    }
+
+    // MARK: - Planning
+
+    /// Selects the travel documents to back-fill from a collection. Add-only keeps only
+    /// documents whose `id` is missing on the destination; `--update-existing` keeps all.
+    private func planCollection(
+        _ name: String, from source: MongoDatabase, to destination: MongoDatabase,
+        titleProvider: (Document) -> String
+    ) async throws -> [PlannedDoc] {
+        let existing = try await uuidSet(of: name, in: destination)
+
+        var planned: [PlannedDoc] = []
+        for try await document in source[name].find() {
+            guard let uuid = document["id"] as? String, !uuid.isEmpty else {
+                // Without a UUID id we can't identify it; skip rather than guess.
+                continue
+            }
+            let isNew = !existing.contains(uuid)
+            guard isNew || updateExisting else { continue }
+            planned.append(
+                PlannedDoc(
+                    uuid: uuid, title: titleProvider(document), document: document, isNew: isNew))
+        }
+        return planned.sorted {
+            $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending
+        }
+    }
+
+    /// Resolves each item's references against the destination, collecting the ones that are
+    /// missing (with their travel copy, if any, for the copy-the-dependency option).
+    private func analyzeReferences(
+        _ planned: [PlannedDoc], collection: String, source: MongoDatabase,
+        destinationIds: [String: Set<String>]
+    ) async throws -> [ContentAnalysis] {
+        var analyses: [ContentAnalysis] = []
+        for item in planned {
+            var missing: [MissingDependency] = []
+            var sounds: [String] = []
+            var seen = Set<EntityReference>()
+
+            for reference in ContentReferences.references(in: item.document, collection: collection)
+            {
+                guard seen.insert(reference).inserted else { continue }
+                guard let refCollection = reference.kind.collection else {
+                    sounds.append(reference.identifier)
+                    continue
+                }
+                if destinationIds[refCollection]?.contains(reference.identifier) == true {
+                    continue
+                }
+
+                let sourceDocument = try await source[refCollection].findOne([
+                    "id": reference.identifier
+                ])
+                let name =
+                    sourceDocument.flatMap { ($0["name"] as? String) ?? ($0["title"] as? String) }
+                missing.append(
+                    MissingDependency(
+                        reference: reference, name: name, sourceDocument: sourceDocument))
+            }
+            analyses.append(
+                ContentAnalysis(
+                    doc: item, missing: missing,
+                    unverifiableSounds: Array(Set(sounds)).sorted()
+                ))
+        }
+        return analyses
+    }
+
+    // MARK: - Applying
+
+    /// Copies content that doesn't carry references (animations) straight across.
+    private func applyPlain(
+        _ planned: [PlannedDoc], collection: String, into destination: MongoDatabase,
+        modified: inout Set<String>
+    ) async throws -> ApplyResult {
+        var result = ApplyResult()
+        guard !planned.isEmpty else { return result }
+
+        print("Copying \(collection)...")
+        for item in planned {
+            let inserted = try await upsertByUUID(
+                item.document, uuid: item.uuid, into: destination[collection],
+                label: "\(singular(collection)) '\(item.title)'")
+            if inserted { result.added += 1 } else { result.updated += 1 }
+        }
+        modified.insert(collection)
+        return result
+    }
+
+    /// Copies reference-bearing content, prompting per item when references are missing.
+    private func applyReferenceBearing(
+        _ analyses: [ContentAnalysis], collection: String, into destination: MongoDatabase,
+        modified: inout Set<String>
+    ) async throws -> ApplyResult {
+        var result = ApplyResult()
+        guard !analyses.isEmpty else { return result }
+
+        print("Copying \(collection)...")
+        for analysis in analyses {
+            if !analysis.missing.isEmpty {
+                let choice = assumeYes ? .skip : promptForMissing(analysis, collection: collection)
+                switch choice {
+                case .abort:
+                    throw failWithMessage("Back-fill aborted.")
+                case .skip:
+                    print("  Skipped \(singular(collection)) '\(analysis.doc.title)'.")
+                    result.skipped += 1
+                    continue
+                case .copyDeps:
+                    for dependency in analysis.missing {
+                        guard let document = dependency.sourceDocument,
+                            let depCollection = dependency.reference.kind.collection
+                        else { continue }
+                        _ = try await upsertByUUID(
+                            document, uuid: dependency.reference.identifier,
+                            into: destination[depCollection],
+                            label:
+                                "\(dependency.reference.kind.label) '\(dependency.name ?? dependency.reference.identifier)'"
+                        )
+                        result.dependenciesCopied += 1
+                        modified.insert(depCollection)
+                    }
+                case .copyAnyway:
+                    break
+                }
+            }
+
+            let inserted = try await upsertByUUID(
+                analysis.doc.document, uuid: analysis.doc.uuid, into: destination[collection],
+                label: "\(singular(collection)) '\(analysis.doc.title)'")
+            if inserted { result.added += 1 } else { result.updated += 1 }
+            modified.insert(collection)
+        }
+        return result
+    }
+
+    // MARK: - Database helpers
+
+    /// All UUID `id` values present in a destination collection.
+    private func uuidSet(of collection: String, in db: MongoDatabase) async throws -> Set<String> {
+        var ids = Set<String>()
+        for try await document in db[collection].find().project(["id": 1]) {
+            if let id = document["id"] as? String { ids.insert(id) }
+        }
+        return ids
+    }
+
+    /// Upserts a document into a collection matched on its UUID `id`. Returns true if the
+    /// document was newly inserted, false if it replaced an existing one.
+    @discardableResult
+    private func upsertByUUID(
+        _ document: Document, uuid: String, into collection: MongoCollection, label: String
+    ) async throws -> Bool {
+        let reply = try await collection.upsert(document, where: ["id": uuid])
+        guard reply.ok == 1, reply.writeErrors?.isEmpty != false else {
+            throw failWithMessage("Failed to copy \(label) to the mainline server: \(reply)")
+        }
+        let inserted = reply.upserted?.isEmpty == false
+        print("  \(inserted ? "Added" : "Updated") \(label)")
+        return inserted
+    }
+
+    // MARK: - Cache invalidation
+
+    /// Asks the mainline creature-server to invalidate the caches for the collections we
+    /// just wrote to, so connected consoles re-pull the new data. The data is already in
+    /// the database, so a failed invalidation is reported as a warning rather than fatal.
+    private func invalidateCaches(for collections: Set<String>) async {
+        guard !skipCacheInvalidation, !collections.isEmpty else { return }
+
+        print("")
+        print("Invalidating caches on the mainline server (\(server.serverHostname))...")
+        // Stable, readable order.
+        let order = [
+            "animations", "dialog_scripts", "storyboards", "creatures", "fixtures", "playlists",
+        ]
+        for collection in order where collections.contains(collection) {
+            let (label, result) = await invalidateCache(for: collection)
+            switch result {
+            case .success(let status):
+                print("  \(label) cache invalidated: \(status.message)")
+            case .failure(let error):
+                print(
+                    "  Warning: \(label) cache invalidation failed: "
+                        + ServerError.detailedMessage(from: error))
+            }
+        }
+    }
+
+    /// Maps a collection name to the matching `CreatureServerClient` invalidation call.
+    private func invalidateCache(for collection: String) async -> (
+        String, Result<StatusDTO, ServerError>
+    ) {
+        switch collection {
+        case "animations": return ("animation", await server.invalidateAnimationCache())
+        case "dialog_scripts": return ("dialog script", await server.invalidateDialogScriptCache())
+        case "storyboards": return ("storyboard", await server.invalidateStoryboardCache())
+        case "creatures": return ("creature", await server.invalidateCreatureCache())
+        case "fixtures": return ("fixture", await server.invalidateFixtureCache())
+        case "playlists": return ("playlist", await server.invalidatePlaylistCache())
+        default:
+            return (
+                collection,
+                .failure(.serverError("no cache invalidation available for '\(collection)'"))
+            )
+        }
+    }
+
+    // MARK: - Titles
+
+    private func animationTitle(_ document: Document) -> String {
+        if let metadata = document["metadata"] as? Document,
+            let title = metadata["title"] as? String,
+            !title.isEmpty
+        {
+            return title
+        }
+        return (document["id"] as? String) ?? "(untitled)"
+    }
+
+    private func titleField(_ document: Document) -> String {
+        if let title = document["title"] as? String, !title.isEmpty { return title }
+        return (document["id"] as? String) ?? "(untitled)"
+    }
+
+    /// Singular, human-readable label for a collection, used in messages.
+    private func singular(_ collection: String) -> String {
+        switch collection {
+        case "animations": return "animation"
+        case "dialog_scripts": return "dialog script"
+        case "storyboards": return "storyboard"
+        case "creatures": return "creature"
+        case "fixtures": return "fixture"
+        case "playlists": return "playlist"
+        default: return collection
+        }
+    }
+
+    // MARK: - User interaction
+
+    private func confirmIfNeeded() throws {
+        guard !assumeYes else { return }
+        print(
+            "Copy the above into the mainline server (\(mainlineServer))? Type 'yes' to continue: ",
+            terminator: "")
+        guard let answer = readLine(), answer.lowercased() == "yes" else {
+            throw failWithMessage("Back-fill cancelled.")
+        }
+        print("")
+    }
+
+    private func promptForMissing(_ analysis: ContentAnalysis, collection: String) -> MissingChoice
+    {
+        let copyable = analysis.missing.filter(\.canCopy).count
+        let kind = singular(collection)
+
+        print("")
+        print(
+            "The \(kind) '\(analysis.doc.title)' references items missing on the mainline server:")
+        for dependency in analysis.missing {
+            let name = dependency.name.map { " (\($0))" } ?? ""
+            let status = dependency.canCopy ? "" : " — not found on travel either; cannot copy"
+            print(
+                "  - \(dependency.reference.kind.label) \(dependency.reference.identifier)\(name)\(status)"
+            )
+        }
+
+        while true {
+            print("What would you like to do?")
+            print("  [c] copy the \(kind) anyway (leave references dangling)")
+            print("  [d] copy the \(copyable) copyable item(s) from travel, then the \(kind)")
+            print("  [s] skip this \(kind)")
+            print("  [a] abort the back-fill")
+            print("> ", terminator: "")
+
+            switch readLine()?.trimmingCharacters(in: .whitespaces).lowercased().first {
+            case "c": return .copyAnyway
+            case "d": return .copyDeps
+            case "s": return .skip
+            case "a": return .abort
+            default: print("Please enter c, d, s, or a.")
+            }
+        }
+    }
+
+    // MARK: - Output
+
+    private func printPreview(
+        animations: [PlannedDoc], dialogScripts: [ContentAnalysis], storyboards: [ContentAnalysis]
+    ) {
+        let mode = updateExisting ? "add + update" : "add-only"
+        print("")
+        print("Back-fill plan (travel \(travelServer) → mainline \(mainlineServer)), \(mode):")
+        print("")
+        printPlainSection("Animations", animations)
+        print("")
+        printAnalysisSection("Dialog scripts", dialogScripts)
+        print("")
+        printAnalysisSection("Storyboards", storyboards)
+        print("")
+    }
+
+    private func printPlainSection(_ title: String, _ items: [PlannedDoc]) {
+        guard !items.isEmpty else {
+            print("\(title): none to copy.")
+            return
+        }
+        print("\(title) to copy (\(items.count)):")
+        for item in items {
+            print("  - \(item.title)\(item.isNew ? "" : " [update]")")
+        }
+    }
+
+    private func printAnalysisSection(_ title: String, _ analyses: [ContentAnalysis]) {
+        guard !analyses.isEmpty else {
+            print("\(title): none to copy.")
+            return
+        }
+        print("\(title) to copy (\(analyses.count)):")
+        for analysis in analyses {
+            print("  - \(analysis.doc.title)\(analysis.doc.isNew ? "" : " [update]")")
+            for dependency in analysis.missing {
+                let name = dependency.name.map { " (\($0))" } ?? ""
+                let status = dependency.canCopy ? "missing" : "missing, dangling on travel"
+                print(
+                    "      ↳ \(status): \(dependency.reference.kind.label) \(dependency.reference.identifier)\(name)"
+                )
+            }
+            if !analysis.unverifiableSounds.isEmpty {
+                print(
+                    "      ↳ references sound file(s) (can't verify — files on disk): "
+                        + analysis.unverifiableSounds.joined(separator: ", "))
+            }
+        }
+    }
+
+    private func printSummary(
+        animations: ApplyResult, dialogScripts: ApplyResult, storyboards: ApplyResult
+    ) {
+        var parts: [String] = []
+        func describe(_ name: String, _ result: ApplyResult) {
+            if result.added > 0 { parts.append("\(result.added) \(name)(s) added") }
+            if result.updated > 0 { parts.append("\(result.updated) \(name)(s) updated") }
+            if result.skipped > 0 { parts.append("\(result.skipped) \(name)(s) skipped") }
+        }
+        describe("animation", animations)
+        describe("dialog script", dialogScripts)
+        describe("storyboard", storyboards)
+
+        let dependenciesCopied =
+            animations.dependenciesCopied + dialogScripts.dependenciesCopied
+            + storyboards.dependenciesCopied
+        if dependenciesCopied > 0 {
+            parts.append("\(dependenciesCopied) dependency item(s) copied")
+        }
+        if parts.isEmpty { parts.append("nothing changed") }
+
+        print("")
+        print("Done! Back-filled into \(mainlineServer): " + parts.joined(separator: ", ") + ".")
+    }
+}

--- a/Common/Sources/CreatureCLI/migrateDatabaseCommand.swift
+++ b/Common/Sources/CreatureCLI/migrateDatabaseCommand.swift
@@ -7,12 +7,13 @@ extension CreatureCLI.Util {
     struct MigrateDatabase: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "migrate-database",
-            abstract: "Copy the creature database from the mainline server to the travel server",
+            abstract: "Merge the creature database from the mainline server into the travel server",
             discussion: """
-                Connects directly to MongoDB on both servers and copies every collection \
-                (documents and indexes) from the mainline server to the travel server. The \
-                travel server's copy of the database is replaced so it exactly mirrors the \
-                mainline server.
+                Connects directly to MongoDB on both servers and merges every collection \
+                (documents and indexes) from the mainline server into the travel server. \
+                Documents are matched by _id: ones that exist on both servers are \
+                overwritten with the mainline copy (the mainline server always wins), and \
+                documents that only exist on the travel server are left alone.
 
                 Servers may be given as a hostname or IP (the default port \
                 \(MongoServerAddress.defaultPort) is assumed), host:port, or a full \
@@ -23,14 +24,17 @@ extension CreatureCLI.Util {
         @Option(help: "Hostname or IP of the mainline (source) MongoDB server")
         var mainlineServer: String
 
+        @Option(help: "Port of the mainline MongoDB server")
+        var mainlinePort: Int = MongoServerAddress.defaultPort
+
         @Option(help: "Hostname or IP of the travel (destination) MongoDB server")
         var travelServer: String
 
+        @Option(help: "Port of the travel MongoDB server")
+        var travelPort: Int = MongoServerAddress.defaultPort
+
         @Option(help: "Name of the database to migrate")
         var database: String = "creature_server"
-
-        @Option(help: "Number of documents to copy per batch")
-        var batchSize: Int = 500
 
         @Flag(help: "Show what would be copied without writing anything")
         var dryRun: Bool = false
@@ -41,18 +45,13 @@ extension CreatureCLI.Util {
         @OptionGroup()
         var globalOptions: GlobalOptions
 
-        func validate() throws {
-            guard batchSize > 0 else {
-                throw ValidationError("--batch-size must be greater than zero")
-            }
-        }
-
         func run() async throws {
             let plan = MigrationPlan(
                 mainlineServer: mainlineServer,
+                mainlinePort: mainlinePort,
                 travelServer: travelServer,
+                travelPort: travelPort,
                 database: database,
-                batchSize: batchSize,
                 dryRun: dryRun,
                 assumeYes: assumeYes
             )
@@ -67,23 +66,28 @@ extension CreatureCLI.Util {
 /// plumbing so it can run inside the traced `@Sendable` closure.
 private struct MigrationPlan: Sendable {
     let mainlineServer: String
+    let mainlinePort: Int
     let travelServer: String
+    let travelPort: Int
     let database: String
-    let batchSize: Int
     let dryRun: Bool
     let assumeYes: Bool
 
     private struct CollectionResult {
         let name: String
         let documents: Int
+        let added: Int
+        let updated: Int
         let indexes: Int
+
+        var unchanged: Int { documents - added - updated }
     }
 
     func execute() async throws {
         let mainlineURI = try MongoServerAddress.connectionURI(
-            for: mainlineServer, database: database)
+            for: mainlineServer, database: database, port: mainlinePort)
         let travelURI = try MongoServerAddress.connectionURI(
-            for: travelServer, database: database)
+            for: travelServer, database: database, port: travelPort)
 
         print("Connecting to mainline server at \(mainlineServer)...")
         let source: MongoDatabase
@@ -158,7 +162,9 @@ private struct MigrationPlan: Sendable {
         guard !assumeYes else { return }
 
         print(
-            "This will REPLACE database '\(database)' on the travel server (\(travelServer)).")
+            "This will merge database '\(database)' from the mainline server into the travel "
+                + "server (\(travelServer)). Documents that exist on both servers will be "
+                + "overwritten with the mainline copy.")
         print("Type 'yes' to continue: ", terminator: "")
         guard let answer = readLine(), answer.lowercased() == "yes" else {
             throw failWithMessage("Migration cancelled.")
@@ -166,46 +172,49 @@ private struct MigrationPlan: Sendable {
         print("")
     }
 
+    /// Merges one collection: every mainline document is upserted into the travel server
+    /// by `_id`, so mainline always wins and travel-only documents are left alone.
     private func copy(
         collection name: String, from source: MongoDatabase, to destination: MongoDatabase
     ) async throws -> CollectionResult {
         let sourceCollection = source[name]
         let destinationCollection = destination[name]
 
-        print("Copying \(name)...")
-        try await destinationCollection.drop()
+        print("Merging \(name)...")
 
-        var copied = 0
-        var batch: [Document] = []
-        batch.reserveCapacity(batchSize)
+        var documents = 0
+        var added = 0
+        var updated = 0
 
         for try await document in sourceCollection.find() {
-            batch.append(document)
-            if batch.count >= batchSize {
-                copied += try await insert(batch: batch, into: destinationCollection, named: name)
-                batch.removeAll(keepingCapacity: true)
+            guard let id = document["_id"] else {
+                throw failWithMessage(
+                    "A document in '\(name)' on the mainline server has no _id; "
+                        + "refusing to continue.")
             }
-        }
-        if !batch.isEmpty {
-            copied += try await insert(batch: batch, into: destinationCollection, named: name)
+
+            let reply = try await destinationCollection.upsert(document, where: ["_id": id])
+            guard reply.ok == 1, reply.writeErrors?.isEmpty != false else {
+                throw failWithMessage(
+                    "Upsert into '\(name)' on the travel server failed: \(reply)")
+            }
+
+            documents += 1
+            if reply.upserted?.isEmpty == false {
+                added += 1
+            } else if reply.updatedCount > 0 {
+                updated += 1
+            }
         }
 
         let indexes = try await copyIndexes(
             from: sourceCollection, to: destinationCollection, named: name)
 
-        print("  \(formatNumber(UInt64(copied))) documents, \(indexes) indexes")
-        return CollectionResult(name: name, documents: copied, indexes: indexes)
-    }
-
-    private func insert(
-        batch: [Document], into collection: MongoCollection, named name: String
-    ) async throws -> Int {
-        let reply = try await collection.insertMany(batch)
-        guard reply.ok == 1, reply.writeErrors?.isEmpty != false else {
-            throw failWithMessage(
-                "Insert into '\(name)' on the travel server failed: \(reply.debugDescription)")
-        }
-        return reply.insertCount
+        print(
+            "  \(formatNumber(UInt64(documents))) documents "
+                + "(\(added) added, \(updated) updated), \(indexes) indexes")
+        return CollectionResult(
+            name: name, documents: documents, added: added, updated: updated, indexes: indexes)
     }
 
     /// Re-creates the source collection's non-`_id` indexes on the destination. Index
@@ -242,6 +251,8 @@ private struct MigrationPlan: Sendable {
 
     private func printSummary(of results: [CollectionResult]) {
         let totalDocuments = results.reduce(0) { $0 + $1.documents }
+        let totalAdded = results.reduce(0) { $0 + $1.added }
+        let totalUpdated = results.reduce(0) { $0 + $1.updated }
 
         print("")
         printTable(
@@ -249,11 +260,15 @@ private struct MigrationPlan: Sendable {
             columns: [
                 TableColumn(title: "Collection") { $0.name },
                 TableColumn(title: "Documents") { formatNumber(UInt64($0.documents)) },
+                TableColumn(title: "Added") { String($0.added) },
+                TableColumn(title: "Updated") { String($0.updated) },
+                TableColumn(title: "Unchanged") { String($0.unchanged) },
                 TableColumn(title: "Indexes") { String($0.indexes) },
             ])
         print("")
         print(
-            "Done! Copied \(formatNumber(UInt64(totalDocuments))) documents in "
-                + "\(results.count) collections from \(mainlineServer) to \(travelServer).")
+            "Done! Merged \(formatNumber(UInt64(totalDocuments))) documents "
+                + "(\(totalAdded) added, \(totalUpdated) updated) in \(results.count) "
+                + "collections from \(mainlineServer) into \(travelServer).")
     }
 }

--- a/Common/Sources/CreatureCLI/migrateDatabaseCommand.swift
+++ b/Common/Sources/CreatureCLI/migrateDatabaseCommand.swift
@@ -1,0 +1,259 @@
+import ArgumentParser
+import Foundation
+import MongoKitten
+
+extension CreatureCLI.Util {
+
+    struct MigrateDatabase: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "migrate-database",
+            abstract: "Copy the creature database from the mainline server to the travel server",
+            discussion: """
+                Connects directly to MongoDB on both servers and copies every collection \
+                (documents and indexes) from the mainline server to the travel server. The \
+                travel server's copy of the database is replaced so it exactly mirrors the \
+                mainline server.
+
+                Servers may be given as a hostname or IP (the default port \
+                \(MongoServerAddress.defaultPort) is assumed), host:port, or a full \
+                mongodb:// URI.
+                """
+        )
+
+        @Option(help: "Hostname or IP of the mainline (source) MongoDB server")
+        var mainlineServer: String
+
+        @Option(help: "Hostname or IP of the travel (destination) MongoDB server")
+        var travelServer: String
+
+        @Option(help: "Name of the database to migrate")
+        var database: String = "creature_server"
+
+        @Option(help: "Number of documents to copy per batch")
+        var batchSize: Int = 500
+
+        @Flag(help: "Show what would be copied without writing anything")
+        var dryRun: Bool = false
+
+        @Flag(name: [.customLong("yes"), .customShort("y")], help: "Skip the confirmation prompt")
+        var assumeYes: Bool = false
+
+        @OptionGroup()
+        var globalOptions: GlobalOptions
+
+        func validate() throws {
+            guard batchSize > 0 else {
+                throw ValidationError("--batch-size must be greater than zero")
+            }
+        }
+
+        func run() async throws {
+            let plan = MigrationPlan(
+                mainlineServer: mainlineServer,
+                travelServer: travelServer,
+                database: database,
+                batchSize: batchSize,
+                dryRun: dryRun,
+                assumeYes: assumeYes
+            )
+            try await tracedRun("util.migrate-database", config: globalOptions) {
+                try await plan.execute()
+            }
+        }
+    }
+}
+
+/// The full source → destination database copy, separated from the ArgumentParser
+/// plumbing so it can run inside the traced `@Sendable` closure.
+private struct MigrationPlan: Sendable {
+    let mainlineServer: String
+    let travelServer: String
+    let database: String
+    let batchSize: Int
+    let dryRun: Bool
+    let assumeYes: Bool
+
+    private struct CollectionResult {
+        let name: String
+        let documents: Int
+        let indexes: Int
+    }
+
+    func execute() async throws {
+        let mainlineURI = try MongoServerAddress.connectionURI(
+            for: mainlineServer, database: database)
+        let travelURI = try MongoServerAddress.connectionURI(
+            for: travelServer, database: database)
+
+        print("Connecting to mainline server at \(mainlineServer)...")
+        let source: MongoDatabase
+        do {
+            source = try await MongoDatabase.connect(to: mainlineURI)
+        } catch {
+            throw failWithMessage(
+                "Unable to connect to the mainline server (\(mainlineServer)): \(error)")
+        }
+
+        print("Connecting to travel server at \(travelServer)...")
+        let destination: MongoDatabase
+        do {
+            destination = try await MongoDatabase.connect(to: travelURI)
+        } catch {
+            throw failWithMessage(
+                "Unable to connect to the travel server (\(travelServer)): \(error)")
+        }
+
+        let collections = try await sourceCollections(in: source)
+        guard !collections.isEmpty else {
+            throw failWithMessage(
+                "Database '\(database)' on the mainline server has no collections to copy.")
+        }
+
+        try await printPreview(of: collections)
+
+        if dryRun {
+            print("Dry run — nothing was copied.")
+            return
+        }
+
+        try confirmOverwriteIfNeeded()
+
+        var results: [CollectionResult] = []
+        for collection in collections {
+            let result = try await copy(
+                collection: collection.name, from: source, to: destination)
+            results.append(result)
+        }
+
+        printSummary(of: results)
+    }
+
+    /// All user collections in the source database, sorted by name for stable output.
+    private func sourceCollections(in source: MongoDatabase) async throws -> [MongoCollection] {
+        let collections = try await source.listCollections()
+        return
+            collections
+            .filter { !$0.name.hasPrefix("system.") }
+            .sorted { $0.name < $1.name }
+    }
+
+    private func printPreview(of collections: [MongoCollection]) async throws {
+        var counts: [(name: String, count: Int)] = []
+        for collection in collections {
+            counts.append((collection.name, try await collection.count()))
+        }
+
+        print("")
+        print("Database '\(database)' on the mainline server:")
+        printTable(
+            counts,
+            columns: [
+                TableColumn(title: "Collection") { $0.name },
+                TableColumn(title: "Documents") { formatNumber(UInt64($0.count)) },
+            ])
+        print("")
+    }
+
+    private func confirmOverwriteIfNeeded() throws {
+        guard !assumeYes else { return }
+
+        print(
+            "This will REPLACE database '\(database)' on the travel server (\(travelServer)).")
+        print("Type 'yes' to continue: ", terminator: "")
+        guard let answer = readLine(), answer.lowercased() == "yes" else {
+            throw failWithMessage("Migration cancelled.")
+        }
+        print("")
+    }
+
+    private func copy(
+        collection name: String, from source: MongoDatabase, to destination: MongoDatabase
+    ) async throws -> CollectionResult {
+        let sourceCollection = source[name]
+        let destinationCollection = destination[name]
+
+        print("Copying \(name)...")
+        try await destinationCollection.drop()
+
+        var copied = 0
+        var batch: [Document] = []
+        batch.reserveCapacity(batchSize)
+
+        for try await document in sourceCollection.find() {
+            batch.append(document)
+            if batch.count >= batchSize {
+                copied += try await insert(batch: batch, into: destinationCollection, named: name)
+                batch.removeAll(keepingCapacity: true)
+            }
+        }
+        if !batch.isEmpty {
+            copied += try await insert(batch: batch, into: destinationCollection, named: name)
+        }
+
+        let indexes = try await copyIndexes(
+            from: sourceCollection, to: destinationCollection, named: name)
+
+        print("  \(formatNumber(UInt64(copied))) documents, \(indexes) indexes")
+        return CollectionResult(name: name, documents: copied, indexes: indexes)
+    }
+
+    private func insert(
+        batch: [Document], into collection: MongoCollection, named name: String
+    ) async throws -> Int {
+        let reply = try await collection.insertMany(batch)
+        guard reply.ok == 1, reply.writeErrors?.isEmpty != false else {
+            throw failWithMessage(
+                "Insert into '\(name)' on the travel server failed: \(reply.debugDescription)")
+        }
+        return reply.insertCount
+    }
+
+    /// Re-creates the source collection's non-`_id` indexes on the destination. Index
+    /// creation failures (e.g. an option MongoDB 4.4 doesn't support) are reported as
+    /// warnings so one exotic index can't abort the whole migration.
+    private func copyIndexes(
+        from source: MongoCollection, to destination: MongoCollection, named name: String
+    ) async throws -> Int {
+        let sourceIndexes = try await source.listIndexes().drain()
+
+        let indexes =
+            sourceIndexes
+            .filter { $0.name != "_id_" }
+            .map { index -> CreateIndexes.Index in
+                var newIndex = CreateIndexes.Index(named: index.name, keys: index.key)
+                newIndex.unique = index.unique
+                newIndex.sparse = index.sparse
+                newIndex.expireAfterSeconds = index.expireAfterSeconds.map(Int.init)
+                return newIndex
+            }
+
+        guard !indexes.isEmpty else { return 0 }
+
+        do {
+            try await destination.createIndexes(indexes)
+        } catch {
+            print(
+                "  Warning: couldn't re-create indexes on '\(name)': \(error). "
+                    + "The documents were copied; create the indexes manually if needed.")
+            return 0
+        }
+        return indexes.count
+    }
+
+    private func printSummary(of results: [CollectionResult]) {
+        let totalDocuments = results.reduce(0) { $0 + $1.documents }
+
+        print("")
+        printTable(
+            results,
+            columns: [
+                TableColumn(title: "Collection") { $0.name },
+                TableColumn(title: "Documents") { formatNumber(UInt64($0.documents)) },
+                TableColumn(title: "Indexes") { String($0.indexes) },
+            ])
+        print("")
+        print(
+            "Done! Copied \(formatNumber(UInt64(totalDocuments))) documents in "
+                + "\(results.count) collections from \(mainlineServer) to \(travelServer).")
+    }
+}

--- a/Common/Sources/CreatureCLI/migrateDatabaseCommand.swift
+++ b/Common/Sources/CreatureCLI/migrateDatabaseCommand.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import CreatureMigration
 import Foundation
 import MongoKitten
 
@@ -84,28 +85,10 @@ private struct MigrationPlan: Sendable {
     }
 
     func execute() async throws {
-        let mainlineURI = try MongoServerAddress.connectionURI(
-            for: mainlineServer, database: database, port: mainlinePort)
-        let travelURI = try MongoServerAddress.connectionURI(
-            for: travelServer, database: database, port: travelPort)
-
-        print("Connecting to mainline server at \(mainlineServer)...")
-        let source: MongoDatabase
-        do {
-            source = try await MongoDatabase.connect(to: mainlineURI)
-        } catch {
-            throw failWithMessage(
-                "Unable to connect to the mainline server (\(mainlineServer)): \(error)")
-        }
-
-        print("Connecting to travel server at \(travelServer)...")
-        let destination: MongoDatabase
-        do {
-            destination = try await MongoDatabase.connect(to: travelURI)
-        } catch {
-            throw failWithMessage(
-                "Unable to connect to the travel server (\(travelServer)): \(error)")
-        }
+        let source = try await connectCreatureDatabase(
+            server: mainlineServer, port: mainlinePort, database: database, role: "mainline")
+        let destination = try await connectCreatureDatabase(
+            server: travelServer, port: travelPort, database: database, role: "travel")
 
         let collections = try await sourceCollections(in: source)
         guard !collections.isEmpty else {

--- a/Common/Sources/CreatureCLI/top.swift
+++ b/Common/Sources/CreatureCLI/top.swift
@@ -35,7 +35,7 @@ struct CreatureCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for interacting with the Creature Server",
         discussion: "A tool for interacting and testing the Creature Server from the command line",
-        version: "2.27.1",
+        version: "2.28.0",
         subcommands: [
             Animations.self, Creatures.self, Debug.self, Dialog.self, Fixtures.self, Metrics.self,
             Network.self, Playlists.self, Sounds.self, Storyboards.self, Util.self, Voice.self,

--- a/Common/Sources/CreatureCLI/top.swift
+++ b/Common/Sources/CreatureCLI/top.swift
@@ -35,7 +35,7 @@ struct CreatureCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for interacting with the Creature Server",
         discussion: "A tool for interacting and testing the Creature Server from the command line",
-        version: "2.26.2",
+        version: "2.27.0",
         subcommands: [
             Animations.self, Creatures.self, Debug.self, Dialog.self, Fixtures.self, Metrics.self,
             Network.self, Playlists.self, Sounds.self, Storyboards.self, Util.self, Voice.self,

--- a/Common/Sources/CreatureCLI/top.swift
+++ b/Common/Sources/CreatureCLI/top.swift
@@ -35,7 +35,7 @@ struct CreatureCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for interacting with the Creature Server",
         discussion: "A tool for interacting and testing the Creature Server from the command line",
-        version: "2.27.0",
+        version: "2.27.1",
         subcommands: [
             Animations.self, Creatures.self, Debug.self, Dialog.self, Fixtures.self, Metrics.self,
             Network.self, Playlists.self, Sounds.self, Storyboards.self, Util.self, Voice.self,

--- a/Common/Sources/CreatureCLI/utilCommand.swift
+++ b/Common/Sources/CreatureCLI/utilCommand.swift
@@ -7,7 +7,7 @@ extension CreatureCLI {
     struct Util: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             abstract: "Helper utils that might be fun!",
-            subcommands: [Oid.self]
+            subcommands: [MigrateDatabase.self, Oid.self]
         )
 
         @OptionGroup()

--- a/Common/Sources/CreatureCLI/utilCommand.swift
+++ b/Common/Sources/CreatureCLI/utilCommand.swift
@@ -7,7 +7,7 @@ extension CreatureCLI {
     struct Util: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             abstract: "Helper utils that might be fun!",
-            subcommands: [MigrateDatabase.self, Oid.self]
+            subcommands: [Backfill.self, MigrateDatabase.self, Oid.self]
         )
 
         @OptionGroup()

--- a/Common/Sources/CreatureMQTT/CHANGELOG.md
+++ b/Common/Sources/CreatureMQTT/CHANGELOG.md
@@ -1,6 +1,47 @@
 # Creature MQTT Changelog
 
-# Creature MQTT Changelog
+## 2.28.0 - 2026-06-12
+- Align creature-mqtt and creature-agent to 2.28.0 to match the rest of the CLI tools.
+- Fix `creature-agent` declaring `--trace-open-ai` twice (the compat alias collided with the auto-derived flag name), which made every invocation fail argument validation. The alias is now `--trace-openai`.
+
+## 2.25.4 - 2026-06-09
+- Align `MQTTMessageProcessor` with the server's ordered websocket ingestion pipeline.
+
+## 2.20.0 - 2026-03-18
+- Add distributed tracing with W3C trace context propagation.
+
+## 2.19.10 - 2026-03-14
+- Add request timeouts to the LLM clients and fix error reporting.
+
+## 2.19.9 - 2026-03-14
+- Fix a cooldown race condition in creature-agent.
+
+## 2.19.8 - 2026-03-07
+- Set a 10s timeout on local LLM health-check requests.
+
+## 2.19.7 - 2026-03-07
+- Use `cancelWhenGracefulShutdown` for the health-check loop.
+
+## 2.19.6 - 2026-03-07
+- Fix the health check blocking graceful shutdown.
+
+## 2.19.5 - 2026-03-07
+- Add a local LLM health check with OTel alerting support.
+
+## 2.19.4 - 2026-03-07
+- Fix slow SIGTERM shutdown in creature-agent and creature-mqtt.
+
+## 2.19.3 - 2026-03-07
+- Fix runaway local LLM generation with stop sequences.
+
+## 2.19.2 - 2026-03-07
+- Rename LM Studio references to generic local LLM naming.
+
+## 2.19.1 - 2026-03-07
+- Use backend-agnostic LLM naming in OTel spans, counters, and descriptions.
+
+## 2.19.0 - 2026-03-07
+- Add LM Studio backend support for creature-agent.
 
 ## 2.18.2 - 2026-03-02
 - Wire systemd env files to CLI flags so services use configured hosts instead of compiled-in defaults.

--- a/Common/Sources/CreatureMQTT/top.swift
+++ b/Common/Sources/CreatureMQTT/top.swift
@@ -76,7 +76,7 @@ struct CreatureMQTT: AsyncParsableCommand {
         abstract: "Bridge Creature websocket events into MQTT",
         discussion:
             "Subscribes to the Creature websocket API and republishes incoming messages to an MQTT broker for Home Assistant.",
-        version: "2.26.1",
+        version: "2.28.0",
         subcommands: [Bridge.self],
         defaultSubcommand: Bridge.self,
         helpNames: .shortAndLong

--- a/Common/Sources/CreatureMigration/ContentReferences.swift
+++ b/Common/Sources/CreatureMigration/ContentReferences.swift
@@ -1,0 +1,117 @@
+import Foundation
+import MongoKitten
+
+/// A single entity that a piece of content (a storyboard or a dialog script) points at.
+/// These are discovered by scanning the document for the known reference keys; the content
+/// itself is stored verbatim/opaque, so extraction is always best-effort.
+public struct EntityReference: Equatable, Hashable, Sendable {
+
+    public enum Kind: String, Sendable, CaseIterable {
+        case animation
+        case creature
+        case playlist
+        case dialogScript
+        case fixture
+        case sound
+
+        /// The destination collection that stores this kind of entity, or `nil` if it
+        /// isn't stored in the database at all (sounds are files on disk, keyed by name).
+        public var collection: String? {
+            switch self {
+            case .animation: return "animations"
+            case .creature: return "creatures"
+            case .playlist: return "playlists"
+            case .dialogScript: return "dialog_scripts"
+            case .fixture: return "fixtures"
+            case .sound: return nil
+            }
+        }
+
+        /// Human-readable singular label for messages.
+        public var label: String {
+            switch self {
+            case .animation: return "animation"
+            case .creature: return "creature"
+            case .playlist: return "playlist"
+            case .dialogScript: return "dialog script"
+            case .fixture: return "fixture"
+            case .sound: return "sound"
+            }
+        }
+    }
+
+    /// What kind of entity this references.
+    public let kind: Kind
+    /// The UUID the reference points at (or, for sounds, the file name).
+    public let identifier: String
+    /// Where the reference was found (a storyboard action `type`, or "dialog turn").
+    public let origin: String
+
+    public init(kind: Kind, identifier: String, origin: String) {
+        self.kind = kind
+        self.identifier = identifier
+        self.origin = origin
+    }
+}
+
+/// Extracts entity references from reference-bearing content. Everything here is read
+/// defensively — any unexpected shape is skipped rather than treated as an error.
+public enum ContentReferences {
+
+    /// Storyboard tile-action key → referenced entity kind. Mirrors the action `type`
+    /// reference table in `docs/storyboard-server-contract.md`.
+    static let storyboardActionKeys: [(key: String, kind: EntityReference.Kind)] = [
+        ("animation_id", .animation),
+        ("creature_id", .creature),
+        ("playlist_id", .playlist),
+        ("script_id", .dialogScript),
+        ("fixture_id", .fixture),
+        ("file_name", .sound),
+    ]
+
+    /// Returns every reference contained in a document from the given collection, in
+    /// document order. Collections that don't reference anything return an empty array.
+    public static func references(in document: Document, collection: String) -> [EntityReference] {
+        switch collection {
+        case "storyboards": return storyboardReferences(in: document)
+        case "dialog_scripts": return dialogScriptReferences(in: document)
+        default: return []
+        }
+    }
+
+    /// Storyboard references live in each tile's opaque `action` object.
+    private static func storyboardReferences(in storyboard: Document) -> [EntityReference] {
+        guard let tiles = storyboard["tiles"] as? Document else { return [] }
+
+        var result: [EntityReference] = []
+        for tileValue in tiles.values {
+            guard let tile = tileValue as? Document,
+                let action = tile["action"] as? Document
+            else { continue }
+
+            let origin = (action["type"] as? String) ?? "unknown"
+            for (key, kind) in storyboardActionKeys {
+                if let identifier = action[key] as? String, !identifier.isEmpty {
+                    result.append(
+                        EntityReference(kind: kind, identifier: identifier, origin: origin))
+                }
+            }
+        }
+        return result
+    }
+
+    /// A dialog script references the creature speaking each of its turns.
+    private static func dialogScriptReferences(in script: Document) -> [EntityReference] {
+        guard let turns = script["turns"] as? Document else { return [] }
+
+        var result: [EntityReference] = []
+        for turnValue in turns.values {
+            guard let turn = turnValue as? Document,
+                let creatureId = turn["creature_id"] as? String, !creatureId.isEmpty
+            else { continue }
+            result.append(
+                EntityReference(kind: .creature, identifier: creatureId, origin: "dialog turn"))
+        }
+        return result
+    }
+}

--- a/Common/Sources/CreatureMigration/MongoConnectionSupport.swift
+++ b/Common/Sources/CreatureMigration/MongoConnectionSupport.swift
@@ -1,0 +1,26 @@
+import Foundation
+import MongoKitten
+
+/// An error from the database migration/back-fill helpers, carrying a user-facing message.
+/// Thrown out of a command's `run()`, ArgumentParser prints it as `Error: <message>`.
+public struct MigrationError: Error, LocalizedError {
+    public let message: String
+    public init(_ message: String) { self.message = message }
+    public var errorDescription: String? { message }
+}
+
+/// Connects to a creature MongoDB server, printing a progress line and turning any
+/// connection failure into a clean `MigrationError` that names the role and address.
+///
+/// `role` is a human label such as "mainline" or "travel" used in the messages.
+public func connectCreatureDatabase(
+    server: String, port: Int, database: String, role: String
+) async throws -> MongoDatabase {
+    let uri = try MongoServerAddress.connectionURI(for: server, database: database, port: port)
+    print("Connecting to \(role) server at \(server)...")
+    do {
+        return try await MongoDatabase.connect(to: uri)
+    } catch {
+        throw MigrationError("Unable to connect to the \(role) server (\(server)): \(error)")
+    }
+}

--- a/Common/Sources/CreatureMigration/MongoServerAddress.swift
+++ b/Common/Sources/CreatureMigration/MongoServerAddress.swift
@@ -6,21 +6,21 @@ import Foundation
 /// (`travel.local:27018`), an IPv6 literal (`::1` or `[::1]:27017`), or a complete
 /// `mongodb://` / `mongodb+srv://` URI. The result always carries a database name in
 /// its path so MongoKitten connects to the right database.
-enum MongoServerAddress {
+public enum MongoServerAddress {
 
-    static let defaultPort = 27017
+    public static let defaultPort = 27017
 
     /// Connect timeout baked into URIs we build from bare hostnames, so a wrong address
     /// fails in seconds instead of MongoKitten's five-minute default.
-    static let connectTimeoutMS = 5000
+    public static let connectTimeoutMS = 5000
 
-    enum AddressError: Error, LocalizedError, Equatable {
+    public enum AddressError: Error, LocalizedError, Equatable {
         case emptyAddress
         case unsupportedScheme(String)
         case invalidPort(String)
         case invalidAddress(String)
 
-        var errorDescription: String? {
+        public var errorDescription: String? {
             switch self {
             case .emptyAddress:
                 return "Server address is empty"
@@ -40,7 +40,7 @@ enum MongoServerAddress {
     /// `port` is used when the address itself doesn't carry one; an explicit port in the
     /// address (`host:27018`) wins. Full `mongodb://` URIs are the user's business and are
     /// passed through untouched apart from getting the database path filled in.
-    static func connectionURI(
+    public static func connectionURI(
         for server: String, database: String, port: Int = defaultPort
     ) throws -> String {
         let trimmed = server.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Common/Tests/CommonTests/ContentReferencesTests.swift
+++ b/Common/Tests/CommonTests/ContentReferencesTests.swift
@@ -1,0 +1,110 @@
+import CreatureMigration
+import MongoKitten
+import Testing
+
+@Suite("ContentReferences tests")
+struct ContentReferencesTests {
+
+    // MARK: - Storyboards
+
+    private func storyboard(tiles: [Document]) -> Document {
+        var tileArray = Document(isArray: true)
+        for tile in tiles { tileArray.append(tile) }
+        return ["id": "sb-1", "title": "Test", "tiles": tileArray]
+    }
+
+    private func tile(action: Document) -> Document {
+        ["id": "tile-1", "action": action]
+    }
+
+    @Test("extracts a play_animation reference from a storyboard")
+    func playAnimation() {
+        let sb = storyboard(tiles: [
+            tile(action: ["type": "play_animation", "animation_id": "anim-uuid", "interrupt": true])
+        ])
+        #expect(
+            ContentReferences.references(in: sb, collection: "storyboards") == [
+                EntityReference(kind: .animation, identifier: "anim-uuid", origin: "play_animation")
+            ])
+    }
+
+    @Test("maps every known storyboard reference key to the right kind")
+    func allReferenceKinds() {
+        let sb = storyboard(tiles: [
+            tile(action: ["type": "play_animation", "animation_id": "a"]),
+            tile(action: ["type": "ad_hoc_speech", "creature_id": "c"]),
+            tile(action: ["type": "start_playlist", "playlist_id": "p"]),
+            tile(action: ["type": "render_dialog", "script_id": "s"]),
+            tile(action: ["type": "fixture_on", "fixture_id": "f"]),
+            tile(action: ["type": "play_sound", "file_name": "noise.wav"]),
+        ])
+        let refs = ContentReferences.references(in: sb, collection: "storyboards")
+        #expect(refs.count == 6)
+        #expect(refs.first { $0.kind == .animation }?.identifier == "a")
+        #expect(refs.first { $0.kind == .creature }?.identifier == "c")
+        #expect(refs.first { $0.kind == .playlist }?.identifier == "p")
+        #expect(refs.first { $0.kind == .dialogScript }?.identifier == "s")
+        #expect(refs.first { $0.kind == .fixture }?.identifier == "f")
+        #expect(refs.first { $0.kind == .sound }?.identifier == "noise.wav")
+    }
+
+    @Test("storyboard tiles without an action, or with empty ids, are skipped")
+    func storyboardDefensiveParsing() {
+        let sb = storyboard(tiles: [
+            ["id": "no-action"],
+            tile(action: ["type": "stop_playlist"]),
+            tile(action: ["type": "play_animation", "animation_id": ""]),
+        ])
+        #expect(ContentReferences.references(in: sb, collection: "storyboards").isEmpty)
+    }
+
+    // MARK: - Dialog scripts
+
+    private func dialogScript(turns: [Document]) -> Document {
+        var turnArray = Document(isArray: true)
+        for turn in turns { turnArray.append(turn) }
+        return ["id": "ds-1", "title": "Scene", "turns": turnArray]
+    }
+
+    @Test("extracts a creature reference from each dialog turn")
+    func dialogTurnsReferenceCreatures() {
+        let ds = dialogScript(turns: [
+            ["creature_id": "mango", "text": "Hello"],
+            ["creature_id": "beaky", "text": "Hi"],
+        ])
+        let refs = ContentReferences.references(in: ds, collection: "dialog_scripts")
+        #expect(
+            refs == [
+                EntityReference(kind: .creature, identifier: "mango", origin: "dialog turn"),
+                EntityReference(kind: .creature, identifier: "beaky", origin: "dialog turn"),
+            ])
+    }
+
+    @Test("dialog turns without a creature_id are skipped")
+    func dialogDefensiveParsing() {
+        let ds = dialogScript(turns: [
+            ["text": "narration with no speaker"],
+            ["creature_id": "", "text": "empty id"],
+        ])
+        #expect(ContentReferences.references(in: ds, collection: "dialog_scripts").isEmpty)
+    }
+
+    // MARK: - General
+
+    @Test("collection mapping matches the schema (sounds have none)")
+    func collectionMapping() {
+        #expect(EntityReference.Kind.animation.collection == "animations")
+        #expect(EntityReference.Kind.creature.collection == "creatures")
+        #expect(EntityReference.Kind.playlist.collection == "playlists")
+        #expect(EntityReference.Kind.dialogScript.collection == "dialog_scripts")
+        #expect(EntityReference.Kind.fixture.collection == "fixtures")
+        #expect(EntityReference.Kind.sound.collection == nil)
+    }
+
+    @Test("collections that don't bear references return nothing")
+    func nonReferenceBearingCollections() {
+        let doc: Document = ["id": "a", "metadata": ["title": "x"] as Document]
+        #expect(ContentReferences.references(in: doc, collection: "animations").isEmpty)
+        #expect(ContentReferences.references(in: doc, collection: "creatures").isEmpty)
+    }
+}

--- a/Common/Tests/CommonTests/MongoServerAddressTests.swift
+++ b/Common/Tests/CommonTests/MongoServerAddressTests.swift
@@ -5,34 +5,68 @@ import Testing
 @Suite("MongoServerAddress tests")
 struct MongoServerAddressTests {
 
+    /// Query string appended to every URI built from a bare host, so bad addresses fail fast.
+    private let timeout = "?connectTimeoutMS=\(MongoServerAddress.connectTimeoutMS)"
+
     // MARK: - Bare hostnames and IPs
 
     @Test("bare hostname gets default port and database")
     func bareHostname() throws {
         let uri = try MongoServerAddress.connectionURI(
             for: "mainstage.local", database: "creature_server")
-        #expect(uri == "mongodb://mainstage.local:27017/creature_server")
+        #expect(uri == "mongodb://mainstage.local:27017/creature_server\(timeout)")
     }
 
     @Test("bare IPv4 address gets default port and database")
     func bareIPv4() throws {
         let uri = try MongoServerAddress.connectionURI(
             for: "10.3.2.11", database: "creature_server")
-        #expect(uri == "mongodb://10.3.2.11:27017/creature_server")
+        #expect(uri == "mongodb://10.3.2.11:27017/creature_server\(timeout)")
     }
 
     @Test("host with explicit port is preserved")
     func hostWithPort() throws {
         let uri = try MongoServerAddress.connectionURI(
             for: "travel.local:27018", database: "creature_server")
-        #expect(uri == "mongodb://travel.local:27018/creature_server")
+        #expect(uri == "mongodb://travel.local:27018/creature_server\(timeout)")
     }
 
     @Test("surrounding whitespace is trimmed")
     func trimsWhitespace() throws {
         let uri = try MongoServerAddress.connectionURI(
             for: "  mainstage.local  ", database: "creature_server")
-        #expect(uri == "mongodb://mainstage.local:27017/creature_server")
+        #expect(uri == "mongodb://mainstage.local:27017/creature_server\(timeout)")
+    }
+
+    // MARK: - Port parameter
+
+    @Test("port parameter is used for a bare hostname")
+    func portParameter() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "travel.local", database: "creature_server", port: 27018)
+        #expect(uri == "mongodb://travel.local:27018/creature_server\(timeout)")
+    }
+
+    @Test("explicit port in the address beats the port parameter")
+    func addressPortWins() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "travel.local:27018", database: "creature_server", port: 9999)
+        #expect(uri == "mongodb://travel.local:27018/creature_server\(timeout)")
+    }
+
+    @Test("port parameter applies to bare IPv6 literals")
+    func portParameterIPv6() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "fd00::5", database: "creature_server", port: 27018)
+        #expect(uri == "mongodb://[fd00::5]:27018/creature_server\(timeout)")
+    }
+
+    @Test("out-of-range port parameter throws")
+    func invalidPortParameter() {
+        #expect(throws: MongoServerAddress.AddressError.invalidPort("0")) {
+            try MongoServerAddress.connectionURI(
+                for: "travel.local", database: "creature_server", port: 0)
+        }
     }
 
     // MARK: - IPv6
@@ -40,21 +74,21 @@ struct MongoServerAddressTests {
     @Test("bare IPv6 literal is bracketed and gets default port")
     func bareIPv6() throws {
         let uri = try MongoServerAddress.connectionURI(for: "::1", database: "creature_server")
-        #expect(uri == "mongodb://[::1]:27017/creature_server")
+        #expect(uri == "mongodb://[::1]:27017/creature_server\(timeout)")
     }
 
     @Test("bracketed IPv6 without port gets default port")
     func bracketedIPv6NoPort() throws {
         let uri = try MongoServerAddress.connectionURI(
             for: "[fd00::5]", database: "creature_server")
-        #expect(uri == "mongodb://[fd00::5]:27017/creature_server")
+        #expect(uri == "mongodb://[fd00::5]:27017/creature_server\(timeout)")
     }
 
     @Test("bracketed IPv6 with port is preserved")
     func bracketedIPv6WithPort() throws {
         let uri = try MongoServerAddress.connectionURI(
             for: "[fd00::5]:27018", database: "creature_server")
-        #expect(uri == "mongodb://[fd00::5]:27018/creature_server")
+        #expect(uri == "mongodb://[fd00::5]:27018/creature_server\(timeout)")
     }
 
     // MARK: - Full URIs

--- a/Common/Tests/CommonTests/MongoServerAddressTests.swift
+++ b/Common/Tests/CommonTests/MongoServerAddressTests.swift
@@ -1,6 +1,5 @@
+import CreatureMigration
 import Testing
-
-@testable import creature_cli
 
 @Suite("MongoServerAddress tests")
 struct MongoServerAddressTests {

--- a/Common/Tests/CommonTests/MongoServerAddressTests.swift
+++ b/Common/Tests/CommonTests/MongoServerAddressTests.swift
@@ -1,0 +1,152 @@
+import Testing
+
+@testable import creature_cli
+
+@Suite("MongoServerAddress tests")
+struct MongoServerAddressTests {
+
+    // MARK: - Bare hostnames and IPs
+
+    @Test("bare hostname gets default port and database")
+    func bareHostname() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "mainstage.local", database: "creature_server")
+        #expect(uri == "mongodb://mainstage.local:27017/creature_server")
+    }
+
+    @Test("bare IPv4 address gets default port and database")
+    func bareIPv4() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "10.3.2.11", database: "creature_server")
+        #expect(uri == "mongodb://10.3.2.11:27017/creature_server")
+    }
+
+    @Test("host with explicit port is preserved")
+    func hostWithPort() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "travel.local:27018", database: "creature_server")
+        #expect(uri == "mongodb://travel.local:27018/creature_server")
+    }
+
+    @Test("surrounding whitespace is trimmed")
+    func trimsWhitespace() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "  mainstage.local  ", database: "creature_server")
+        #expect(uri == "mongodb://mainstage.local:27017/creature_server")
+    }
+
+    // MARK: - IPv6
+
+    @Test("bare IPv6 literal is bracketed and gets default port")
+    func bareIPv6() throws {
+        let uri = try MongoServerAddress.connectionURI(for: "::1", database: "creature_server")
+        #expect(uri == "mongodb://[::1]:27017/creature_server")
+    }
+
+    @Test("bracketed IPv6 without port gets default port")
+    func bracketedIPv6NoPort() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "[fd00::5]", database: "creature_server")
+        #expect(uri == "mongodb://[fd00::5]:27017/creature_server")
+    }
+
+    @Test("bracketed IPv6 with port is preserved")
+    func bracketedIPv6WithPort() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "[fd00::5]:27018", database: "creature_server")
+        #expect(uri == "mongodb://[fd00::5]:27018/creature_server")
+    }
+
+    // MARK: - Full URIs
+
+    @Test("full URI without a database gets the database appended")
+    func fullURIWithoutDatabase() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "mongodb://mainstage.local:27017", database: "creature_server")
+        #expect(uri == "mongodb://mainstage.local:27017/creature_server")
+    }
+
+    @Test("full URI with trailing slash gets the database appended")
+    func fullURITrailingSlash() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "mongodb://mainstage.local:27017/", database: "creature_server")
+        #expect(uri == "mongodb://mainstage.local:27017/creature_server")
+    }
+
+    @Test("full URI with a database is passed through unchanged")
+    func fullURIWithDatabase() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "mongodb://mainstage.local:27017/other_db", database: "creature_server")
+        #expect(uri == "mongodb://mainstage.local:27017/other_db")
+    }
+
+    @Test("query string is preserved when appending the database")
+    func fullURIWithQueryString() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "mongodb://user:pass@mainstage.local:27017?authSource=admin",
+            database: "creature_server")
+        #expect(uri == "mongodb://user:pass@mainstage.local:27017/creature_server?authSource=admin")
+    }
+
+    @Test("mongodb+srv URIs are accepted")
+    func srvURI() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "mongodb+srv://cluster.example.com", database: "creature_server")
+        #expect(uri == "mongodb+srv://cluster.example.com/creature_server")
+    }
+
+    @Test("multi-host URIs get the database appended")
+    func multiHostURI() throws {
+        let uri = try MongoServerAddress.connectionURI(
+            for: "mongodb://host1:27017,host2:27017", database: "creature_server")
+        #expect(uri == "mongodb://host1:27017,host2:27017/creature_server")
+    }
+
+    // MARK: - Errors
+
+    @Test("empty address throws")
+    func emptyAddress() {
+        #expect(throws: MongoServerAddress.AddressError.emptyAddress) {
+            try MongoServerAddress.connectionURI(for: "   ", database: "creature_server")
+        }
+    }
+
+    @Test("non-mongodb scheme throws")
+    func unsupportedScheme() {
+        #expect(throws: MongoServerAddress.AddressError.unsupportedScheme("https")) {
+            try MongoServerAddress.connectionURI(
+                for: "https://mainstage.local", database: "creature_server")
+        }
+    }
+
+    @Test("non-numeric port throws")
+    func nonNumericPort() {
+        #expect(throws: MongoServerAddress.AddressError.invalidPort("abc")) {
+            try MongoServerAddress.connectionURI(
+                for: "mainstage.local:abc", database: "creature_server")
+        }
+    }
+
+    @Test("out-of-range port throws")
+    func outOfRangePort() {
+        #expect(throws: MongoServerAddress.AddressError.invalidPort("99999")) {
+            try MongoServerAddress.connectionURI(
+                for: "mainstage.local:99999", database: "creature_server")
+        }
+    }
+
+    @Test("trailing colon with no port throws")
+    func trailingColon() {
+        #expect(throws: MongoServerAddress.AddressError.invalidAddress("mainstage.local:")) {
+            try MongoServerAddress.connectionURI(
+                for: "mainstage.local:", database: "creature_server")
+        }
+    }
+
+    @Test("unclosed IPv6 bracket throws")
+    func unclosedBracket() {
+        #expect(throws: MongoServerAddress.AddressError.invalidAddress("[fd00::5")) {
+            try MongoServerAddress.connectionURI(for: "[fd00::5", database: "creature_server")
+        }
+    }
+}

--- a/Creature Console.xcodeproj/project.pbxproj
+++ b/Creature Console.xcodeproj/project.pbxproj
@@ -1973,7 +1973,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.26.2;
+				MARKETING_VERSION = 2.27.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -2027,7 +2027,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.26.2;
+				MARKETING_VERSION = 2.27.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2111,7 +2111,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.26.2;
+				MARKETING_VERSION = 2.27.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -2143,7 +2143,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.26.2;
+				MARKETING_VERSION = 2.27.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;

--- a/Creature Console.xcodeproj/project.pbxproj
+++ b/Creature Console.xcodeproj/project.pbxproj
@@ -1973,7 +1973,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.27.0;
+				MARKETING_VERSION = 2.27.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -2027,7 +2027,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.27.0;
+				MARKETING_VERSION = 2.27.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2111,7 +2111,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.27.0;
+				MARKETING_VERSION = 2.27.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -2143,7 +2143,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.27.0;
+				MARKETING_VERSION = 2.27.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;

--- a/Creature Console.xcodeproj/project.pbxproj
+++ b/Creature Console.xcodeproj/project.pbxproj
@@ -1973,7 +1973,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.27.1;
+				MARKETING_VERSION = 2.28.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -2027,7 +2027,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.27.1;
+				MARKETING_VERSION = 2.28.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2111,7 +2111,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.27.1;
+				MARKETING_VERSION = 2.28.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -2143,7 +2143,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.27.1;
+				MARKETING_VERSION = 2.28.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+creature-cli (2.27.0) unstable; urgency=medium
+
+  * New util migrate-database command: copies the creature database
+    (documents and indexes) straight from the mainline MongoDB server to
+    the travel server using MongoKitten, with --dry-run, confirmation
+    prompt, and batched inserts. Works across MongoDB 8 -> 4.4.
+
+ -- April White <april@creature.engineering>  Sat, 13 Jun 2026 01:46:21 +0000
+
 creature-cli (2.26.2) unstable; urgency=medium
 
   * Refactor HTTP client: all REST calls now flow through shared

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+creature-cli (2.27.1) unstable; urgency=medium
+
+  * util migrate-database now merges instead of replacing: documents are
+    upserted by _id so the mainline server always wins, and documents
+    that only exist on the travel server are kept. The --batch-size
+    option is gone; the summary now reports added/updated/unchanged.
+  * New --mainline-port and --travel-port options; bare hostnames now
+    connect with a 5 second timeout instead of MongoKitten's default.
+
+ -- April White <april@creature.engineering>  Sat, 13 Jun 2026 01:53:35 +0000
+
 creature-cli (2.27.0) unstable; urgency=medium
 
   * New util migrate-database command: copies the creature database

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+creature-cli (2.28.0) unstable; urgency=medium
+
+  * New util backfill command: copy road-created animations, dialog
+    scripts, and storyboards from the travel server back into the mainline
+    server. Matches on the UUID id (add-only by default; --update-existing
+    to overwrite). Resolves each storyboard's and dialog script's
+    references and prompts when one is missing on the mainline server
+    (copy anyway / pull the missing item across / skip / abort).
+  * After writing, tells the mainline creature-server to invalidate the
+    caches for the collections that changed (via CreatureServerClient).
+    Use --skip-cache-invalidation to disable.
+  * Version sync: creature-mqtt and creature-agent are bumped to 2.28.0 to
+    match creature-cli (no functional change in those two tools).
+
+ -- April White <april@creature.engineering>  Sat, 13 Jun 2026 02:58:24 +0000
+
 creature-cli (2.27.1) unstable; urgency=medium
 
   * util migrate-database now merges instead of replacing: documents are

--- a/docs/backfill-cli-plan.md
+++ b/docs/backfill-cli-plan.md
@@ -1,0 +1,73 @@
+# Back-fill CLI Utility — Implementation Plan
+
+## Goal
+
+The complement to `migrate-database`: copy the content you create on the **travel** server
+while on the road back into the **mainline** server. Scoped to the collections that actually
+get authored on the road — **animations**, **dialog scripts**, and **storyboards** — rather
+than the whole database.
+
+## Identity
+
+Entities are matched on their UUID `id` field, **not** the Mongo `_id` (the system doesn't use
+the OID). Documents are upserted by `id`, so inserts preserve the source `_id` and the two
+servers stay `_id`-consistent for future `migrate-database` runs.
+
+## CLI Surface
+
+```
+creature-cli util backfill \
+    --mainline-server mainstage.example.com \
+    --travel-server   travel.example.com \
+    [--update-existing] [--dry-run] [--yes] [--skip-cache-invalidation]
+```
+
+- Source = `--travel-server`, destination = `--mainline-server` (with `--*-port` options).
+- **Add-only by default**: only items whose `id` is missing on the mainline server are copied;
+  existing mainline documents are untouched. `--update-existing` also overwrites matches.
+- `--dry-run` previews; `--yes` skips prompts (items with missing references are skipped).
+
+## Reference Resolution
+
+Dialog scripts reference the **creature** speaking each turn. Storyboards reference
+**animations, creatures, fixtures, playlists, and dialog scripts** (via opaque tile actions),
+plus **sounds** by file name (files on disk — can't be verified in the DB).
+
+Reference extraction lives in `ContentReferences` (pure, unit-tested). Before copying a
+reference-bearing item, the back-fill checks each reference against the mainline server —
+counting items being copied in the same run as present (animations and dialog scripts are
+written before storyboards). For any missing reference the user is prompted:
+
+- **[c]** copy the item anyway (leave the reference dangling)
+- **[d]** pull the missing referenced entity from travel across too, then copy the item
+- **[s]** skip this item
+- **[a]** abort
+
+Sounds are surfaced as "can't verify" notes, never blocking.
+
+## Cache Invalidation
+
+After writing, the mainline **creature-server** is told to invalidate the caches for exactly
+the collections that changed, so connected consoles re-pull. This uses the existing
+`CreatureServerClient` methods (`invalidateAnimationCache()`, `invalidateDialogScriptCache()`,
+`invalidateStoryboardCache()`, plus creature/fixture/playlist for any copied dependencies) —
+**not** direct API calls. The call targets the server named by the global `--host`/`--port`
+options (the creature-server HTTP API, separate from the Mongo host). A failed invalidation is
+a warning, not fatal — the data is already written. `--skip-cache-invalidation` disables it.
+
+### Server-side dependency
+
+The creature-server only had `cache-invalidate` HTTP routes for creature/animation/playlist.
+The missing routes (`storyboard-list`, `dialog-script-list`, `fixture`, `sound-list`,
+`ad-hoc-animation-list`, `ad-hoc-sound-list`) were added to `DebugController.h` so the client's
+existing methods have endpoints to hit.
+
+## Code Layout
+
+- `Common/Sources/CreatureCLI/backfillCommand.swift` — `CreatureCLI.Util.Backfill` + the
+  `BackfillPlan` engine (planning, reference analysis, apply-with-prompts, cache invalidation).
+- `Common/Sources/CreatureCLI/ContentReferences.swift` — `EntityReference` + `ContentReferences`
+  extractor (storyboard tile actions, dialog-script turns), pure and testable.
+- `Common/Sources/CreatureCLI/MongoConnectionSupport.swift` — shared `connectCreatureDatabase`
+  helper, reused by `migrate-database` and `backfill`.
+- `Common/Tests/CommonTests/ContentReferencesTests.swift` — extractor tests.

--- a/docs/database-migration-cli-plan.md
+++ b/docs/database-migration-cli-plan.md
@@ -24,23 +24,30 @@ creature-cli util migrate-database \
 - `--mainline-server` (required): hostname/IP of the source (mainstage) MongoDB. May be a bare
   host, `host:port`, or a full `mongodb://` URI.
 - `--travel-server` (required): hostname/IP of the destination (travel) MongoDB, same formats.
+- `--mainline-port` / `--travel-port`: MongoDB port for each server (default 27017); an
+  explicit port in the address wins. URIs built from bare hosts get `connectTimeoutMS=5000`
+  so a wrong address fails in seconds rather than MongoKitten's five-minute default.
 - `--database`: database name, defaults to `creature_server` (matches `DB_NAME` in
   creature-server's `config.h`).
-- `--batch-size`: documents per `insertMany` batch (default 500).
 - `--dry-run`: connect, list collections and counts, but write nothing.
-- `--yes`: skip the interactive confirmation before overwriting the travel database.
+- `--yes`: skip the interactive confirmation before writing to the travel database.
 
 ## Migration Algorithm
+
+The copy is a **merge, not a replace**: documents are matched by `_id`, the mainstage
+server always wins on conflict, and documents that only exist on the travel server are
+left alone.
 
 1. Connect to both servers (fail fast with a clear message naming which side failed).
 2. List collections on the source database.
 3. Show a summary (collection names + document counts) and confirm before touching the
    destination (unless `--yes`).
 4. For each collection:
-   a. Drop the destination collection (travel mirrors mainstage exactly).
-   b. Stream documents from the source in batches and `insertMany` into the destination.
-   c. Re-create non-`_id` indexes on the destination.
-5. Print a summary table of collections, documents copied, and indexes created.
+   a. Stream documents from the source and upsert each into the destination by `_id`
+      (full-document replacement, so the mainline copy wins).
+   b. Re-create non-`_id` indexes on the destination.
+5. Print a summary table of collections, documents merged (added / updated / unchanged),
+   and indexes created.
 
 ## Code Layout
 

--- a/docs/database-migration-cli-plan.md
+++ b/docs/database-migration-cli-plan.md
@@ -1,0 +1,76 @@
+# Database Migration CLI Utility — Implementation Plan
+
+## Goal
+
+Add a `creature-cli` utility that copies the creature server's MongoDB database from the
+**mainstage** server (MongoDB 8) to the **travel** server (MongoDB 4.4), so the travel rig can
+be loaded with the latest animations, creatures, playlists, etc. before going on the road.
+
+## Approach
+
+Use [MongoKitten](https://github.com/orlandos-nl/MongoKitten) (pure-Swift MongoDB driver,
+builds on macOS and Linux, supports MongoDB 3.6+) to talk to both servers directly. Because
+documents are copied as raw BSON `Document`s, nothing version-specific leaks between the
+MongoDB 8 source and the 4.4 destination — the wire protocol (OP_MSG) is common to both.
+
+## CLI Surface
+
+```
+creature-cli util migrate-database \
+    --mainline-server mainstage.example.com \
+    --travel-server travel.example.com
+```
+
+- `--mainline-server` (required): hostname/IP of the source (mainstage) MongoDB. May be a bare
+  host, `host:port`, or a full `mongodb://` URI.
+- `--travel-server` (required): hostname/IP of the destination (travel) MongoDB, same formats.
+- `--database`: database name, defaults to `creature_server` (matches `DB_NAME` in
+  creature-server's `config.h`).
+- `--batch-size`: documents per `insertMany` batch (default 500).
+- `--dry-run`: connect, list collections and counts, but write nothing.
+- `--yes`: skip the interactive confirmation before overwriting the travel database.
+
+## Migration Algorithm
+
+1. Connect to both servers (fail fast with a clear message naming which side failed).
+2. List collections on the source database.
+3. Show a summary (collection names + document counts) and confirm before touching the
+   destination (unless `--yes`).
+4. For each collection:
+   a. Drop the destination collection (travel mirrors mainstage exactly).
+   b. Stream documents from the source in batches and `insertMany` into the destination.
+   c. Re-create non-`_id` indexes on the destination.
+5. Print a summary table of collections, documents copied, and indexes created.
+
+## Code Layout
+
+- `Common/Sources/CreatureCLI/databaseCommand.swift` — `CreatureCLI.Util.MigrateDatabase`
+  subcommand with the orchestration logic.
+- `Common/Sources/CreatureCLI/MongoServerAddress.swift` — small pure helper that normalizes
+  the `--mainline-server` / `--travel-server` values into MongoDB connection URIs
+  (bare host → `mongodb://host:27017`, `host:port` → `mongodb://host:port`, full URI passed
+  through). Pure and unit-testable.
+- `Common/Tests/CommonTests/MongoServerAddressTests.swift` — Swift Testing suite for the
+  address normalization (bare host, host:port, IPv6, full URI, trailing slash, etc.).
+
+## Dependency Changes
+
+- Add `MongoKitten` (from: 7.16.0) to `Common/Package.swift`, **only** as a dependency of the
+  `creature-cli` executable target — the GUI app and other tools don't need a Mongo driver.
+
+## Compatibility Notes
+
+- MongoKitten supports MongoDB 3.6+, so both 8.x and 4.4 are in range.
+- Index options that exist in MongoDB 8 but not 4.4 are unlikely with creature-server's plain
+  indexes; index creation failures are reported as warnings rather than aborting the copy.
+- MongoKitten is pure Swift (NIO-based), so it builds on Linux; the Debian package products
+  (`creature-cli`, `creature-mqtt`, `creature-agent`) must be verified in the Swift Linux
+  container before tagging, per CLAUDE.md.
+
+## Release Checklist
+
+- swift-format all touched files.
+- `cd Common && swift test`.
+- Linux container build of the three packaged products.
+- Bump marketing version + CLI `version` (2.27.0 — new feature), add `debian/changelog`
+  entry, commit, tag.


### PR DESCRIPTION
Adds two MongoDB-direct utilities to `creature-cli` for moving creature data between the **mainline** (mainstage) and **travel** servers, built on MongoKitten. Three tagged releases are bundled here.

## What's in it

### `util migrate-database` (v2.27.0 / v2.27.1)
Mirror the database from the mainline server **into** the travel server before a trip.
- **Merge by `_id`** — mainline wins on conflict; travel-only documents are preserved (it's a merge, not a wipe).
- Flexible server args: bare host, `host:port`, IPv6, or a full `mongodb://` URI, plus `--mainline-port` / `--travel-port`. Bare hosts get a 5s connect timeout so a wrong address fails fast.
- `--dry-run` preview and a confirmation prompt before writing.

### `util backfill` (v2.28.0)
The complement — copy the content you author on the road **back into** the mainline server: **animations, dialog scripts, and storyboards**.
- **Matches on the UUID `id`** (the system's identity), not the Mongo `_id`. **Add-only** by default; `--update-existing` overwrites.
- **Reference-aware**: resolves each storyboard's references (animation/creature/fixture/playlist/dialog-script/sound) and each dialog script's creature refs, and prompts per item when one is missing on the mainline server — copy anyway / pull the missing item across / skip / abort. Reference extraction lives in `ContentReferences` (pure, unit-tested).
- After writing, tells the mainline creature-server to **invalidate the caches** for the collections that changed (via the existing `CreatureServerClient` methods; target = global `--host`). `--skip-cache-invalidation` to disable.

## Structure
The Mongo building blocks (server-address parsing, the connection helper, content-reference extraction) live in a new **`CreatureMigration`** library target, so `CreatureCLI` holds command files only and MongoKitten stays out of the GUI app.

## Release hygiene (2.28.0)
- All CLI tools synced to 2.28.0 (creature-cli, creature-mqtt, creature-agent); Creature Console + Creature TV already at 2.28.0.
- Fixed a pre-existing `creature-agent` bug: `--trace-open-ai` was declared twice, so ArgumentParser rejected **every** invocation. The compat alias is now `--trace-openai`.
- `debian/changelog` and `CreatureMQTT/CHANGELOG.md` brought up to date.

## Verification
- 311 tests pass (`cd Common && swift test`), including new `MongoServerAddress` and `ContentReferences` suites.
- Linux container build green for all three Debian products (creature-cli, creature-mqtt, creature-agent).
- Both tools exercised against the live mainline/travel servers; the real migrate (131 docs) and a real backfill (11 animations + animation cache invalidation) both succeeded.

## Note
Depends on matching `cache-invalidate` routes added to the creature-server (storyboard-list / dialog-script-list / fixture / etc.) in a separate change to that repo. The pre-existing `animation` route covers the backfill case exercised so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)