### PR TITLE
creatures detail --json: full creature config export (2.28.1)

### DIFF
--- a/Common/Sources/Common/Controller/Server/RESTful/CreatureMethods.swift
+++ b/Common/Sources/Common/Controller/Server/RESTful/CreatureMethods.swift
@@ -32,6 +32,20 @@ extension CreatureServerClient {
         return await fetchData(url, returnType: Creature.self)
     }
 
+    /// Fetches a creature's complete stored configuration as raw JSON, exactly as the
+    /// server persists it (every field, `_id` stripped) — for disaster-recovery export.
+    /// Returns the body verbatim rather than decoding into `Creature`, which is a trimmed
+    /// view and would silently drop fields like motors and servo settings.
+    public func exportCreature(creatureId: CreatureIdentifier) async -> Result<String, ServerError>
+    {
+        guard let url = URL(string: makeBaseURL(.http) + "/creature/\(creatureId)/export") else {
+            return .failure(.serverError("unable to make base URL"))
+        }
+        self.logger.debug("Using URL: \(url)")
+
+        return await fetchDataResponse(url).map { String(decoding: $0.data, as: UTF8.self) }
+    }
+
     public func validateCreatureConfig(rawConfig: String) async -> Result<
         CreatureConfigValidationDTO, ServerError
     > {

--- a/Common/Sources/CreatureAgent/top.swift
+++ b/Common/Sources/CreatureAgent/top.swift
@@ -32,7 +32,7 @@ struct CreatureAgent: AsyncParsableCommand {
         abstract: "Listen to MQTT, generate LLM responses, schedule ad-hoc speech",
         discussion:
             "Consumes MQTT topics and uses an LLM backend (OpenAI or local) to generate ad-hoc speech animations on the Creature server.",
-        version: "2.28.0",
+        version: "2.28.1",
         subcommands: [Run.self],
         defaultSubcommand: Run.self,
         helpNames: .shortAndLong

--- a/Common/Sources/CreatureCLI/creaturesCommand.swift
+++ b/Common/Sources/CreatureCLI/creaturesCommand.swift
@@ -75,7 +75,10 @@ extension CreatureCLI {
 
         struct Detail: AsyncParsableCommand {
             static let configuration = CommandConfiguration(
-                abstract: "Show details for a single creature by ID")
+                abstract: "Show details for a single creature by ID",
+                discussion:
+                    "Prints a formatted summary, or with --json dumps the creature's complete stored config as raw JSON — every field the server persists (motors, servo settings, etc.), suitable as a backup or for re-importing. Redirect it to a file: creatures detail <id> --json > creature.json"
+            )
 
             @OptionGroup()
             var globalOptions: GlobalOptions
@@ -83,8 +86,26 @@ extension CreatureCLI {
             @Argument(help: "Creature ID to show")
             var creatureId: CreatureIdentifier
 
+            @Flag(help: "Dump the complete stored creature JSON instead of the formatted summary")
+            var json: Bool = false
+
             func run() async throws {
+                let dumpJSON = json
                 try await tracedRun("creatures.detail", config: globalOptions) { server in
+                    if dumpJSON {
+                        // Raw server export — every stored field, re-importable. The typed
+                        // Creature model is a trimmed view, so we never round-trip through it here.
+                        switch await server.exportCreature(creatureId: creatureId) {
+                        case .success(let rawJSON):
+                            print(rawJSON)
+                        case .failure(let error):
+                            throw failWithMessage(
+                                "Error exporting creature: \(ServerError.detailedMessage(from: error))"
+                            )
+                        }
+                        return
+                    }
+
                     let result = try await server.getCreature(creatureId: creatureId)
                     switch result {
                     case .success(let creature):

--- a/Common/Sources/CreatureCLI/top.swift
+++ b/Common/Sources/CreatureCLI/top.swift
@@ -35,7 +35,7 @@ struct CreatureCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for interacting with the Creature Server",
         discussion: "A tool for interacting and testing the Creature Server from the command line",
-        version: "2.28.0",
+        version: "2.28.1",
         subcommands: [
             Animations.self, Creatures.self, Debug.self, Dialog.self, Fixtures.self, Metrics.self,
             Network.self, Playlists.self, Sounds.self, Storyboards.self, Util.self, Voice.self,

--- a/Common/Sources/CreatureMQTT/CHANGELOG.md
+++ b/Common/Sources/CreatureMQTT/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Creature MQTT Changelog
 
+## 2.28.1 - 2026-06-12
+- Version sync to 2.28.1 to stay aligned with the rest of the CLI tools (creature-cli added a creature-export command). No functional changes to creature-mqtt or creature-agent.
+
 ## 2.28.0 - 2026-06-12
 - Align creature-mqtt and creature-agent to 2.28.0 to match the rest of the CLI tools.
 - Fix `creature-agent` declaring `--trace-open-ai` twice (the compat alias collided with the auto-derived flag name), which made every invocation fail argument validation. The alias is now `--trace-openai`.

--- a/Common/Sources/CreatureMQTT/top.swift
+++ b/Common/Sources/CreatureMQTT/top.swift
@@ -76,7 +76,7 @@ struct CreatureMQTT: AsyncParsableCommand {
         abstract: "Bridge Creature websocket events into MQTT",
         discussion:
             "Subscribes to the Creature websocket API and republishes incoming messages to an MQTT broker for Home Assistant.",
-        version: "2.28.0",
+        version: "2.28.1",
         subcommands: [Bridge.self],
         defaultSubcommand: Bridge.self,
         helpNames: .shortAndLong

--- a/Creature Console.xcodeproj/project.pbxproj
+++ b/Creature Console.xcodeproj/project.pbxproj
@@ -1973,7 +1973,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.28.0;
+				MARKETING_VERSION = 2.28.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -2027,7 +2027,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.28.0;
+				MARKETING_VERSION = 2.28.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2111,7 +2111,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.28.0;
+				MARKETING_VERSION = 2.28.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -2143,7 +2143,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.28.0;
+				MARKETING_VERSION = 2.28.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+creature-cli (2.28.1) unstable; urgency=medium
+
+  * New 'creatures detail <id> --json' flag: dumps a creature's complete
+    stored config as raw JSON (every persisted field — motors, servo
+    settings, etc.) via the server's new /creature/{id}/export endpoint,
+    bypassing the trimmed typed model. Use it for disaster-recovery
+    backups, e.g. when a creature's controller Pi is lost.
+
+ -- April White <april@creature.engineering>  Sat, 13 Jun 2026 06:26:53 +0000
+
 creature-cli (2.28.0) unstable; urgency=medium
 
   * New util backfill command: copy road-created animations, dialog


### PR DESCRIPTION
Disaster-recovery export for creatures, prompted by Beaky's controller Pi dying with no way to get its config out.

## What
- **`creatures detail <id> --json`** dumps a creature's **complete stored JSON** — every persisted field, including `motors`, `servo_frequency`, `position_min/max`, etc. Redirect to a file for a backup:
  ```
  creature-cli creatures detail <id> --json > creature.json
  ```
- New public **`CreatureServerClient.exportCreature(creatureId:)`** calls the server's new `GET /api/v1/creature/{id}/export` endpoint and returns the body **verbatim**.

## Why not reuse the typed model
The client `Creature` model — and the server's REST `CreatureDto` — are a **trimmed view** that omits the physical-controller config (`motors`, servo settings, etc.). Re-encoding through it (the storyboards approach) would silently drop exactly the fields you need to rebuild a controller. So the export bypasses the typed model and emits the raw export-endpoint body, which the server already serves with `_id` stripped and re-importable to `POST /api/v1/creature`.

## Server dependency
Requires the `GET /api/v1/creature/{id}/export` endpoint (added separately to creature-server). Until that build is deployed, the flag will 404 against an older server.

## Release hygiene
- Versions synced to **2.28.1** across creature-cli, creature-mqtt, creature-agent, and the Console + TV apps.
- `debian/changelog` and `CreatureMQTT/CHANGELOG.md` updated.

## Verification
- 311 tests pass; Linux container build green for all three Debian products.
- Live round-trip pending server deployment; the emergency itself was already handled out-of-band via a direct DB export of Beaky (all fields intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)