### PR TITLE
CI: exclude JobStatusStoreTests.swift from the SPM app target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,6 +46,7 @@ let package = Package(
                 "Model/Creature/CreatureHealthTests.swift",
                 "Model/Creature/CreatureImporterTests.swift",
                 "Model/Creature/CreatureModelTests.swift",
+                "Model/Jobs/JobStatusStoreTests.swift",
                 "Model/Playlist/PlaylistImporterTests.swift",
                 "Model/Playlist/PlaylistModelTests.swift",
                 "Model/Server/LogItemTests.swift",


### PR DESCRIPTION
The **Swift** workflow (`swift build` of the root `CreatureConsole` SPM target) has been red on `main` since `JobStatusStoreTests.swift` was added (2.29.2 era) — it's an Xcode-app-target test that `@testable import Creature_Console`, which isn't an SPM module, and it was never added to `Package.swift`'s exclude list like every other colocated `*Tests.swift`.

Adding the one missing exclude. Verified `swift build` is green locally; it's the only colocated test file that was missing from the list.

Pre-existing, unrelated to any release — just fixing the red check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)