### PR TITLE
DRY #8: shared ErrorAlert facade for error-alert plumbing

### DIFF
--- a/Common/Sources/CreatureCLI/top.swift
+++ b/Common/Sources/CreatureCLI/top.swift
@@ -35,7 +35,7 @@ struct CreatureCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for interacting with the Creature Server",
         discussion: "A tool for interacting and testing the Creature Server from the command line",
-        version: "2.34.2",
+        version: "2.34.3",
         subcommands: [
             Animations.self, Creatures.self, Debug.self, Dialog.self, Fixtures.self, Metrics.self,
             Network.self, Playlists.self, Sounds.self, Storyboards.self, Util.self, Voice.self,

--- a/Creature Console.xcodeproj/project.pbxproj
+++ b/Creature Console.xcodeproj/project.pbxproj
@@ -166,6 +166,8 @@
 		11B0488A2EB842B3001B73C5 /* LipSyncUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B048872EB842B3001B73C5 /* LipSyncUtilities.swift */; };
 		11B0488D2EB8430E001B73C5 /* ProcessingOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B0488B2EB8430E001B73C5 /* ProcessingOverlayView.swift */; };
 		11B0488E2EB8430E001B73C5 /* ProcessingOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B0488B2EB8430E001B73C5 /* ProcessingOverlayView.swift */; };
+		FEA1A1E70000000000000002 /* ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA1A1E70000000000000001 /* ErrorAlert.swift */; };
+		FEA1A1E70000000000000003 /* ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA1A1E70000000000000001 /* ErrorAlert.swift */; };
 		11BC3BAC2E98B4E5002A568C /* SimpleKeychain in Frameworks */ = {isa = PBXBuildFile; productRef = 11BC3BAB2E98B4E5002A568C /* SimpleKeychain */; };
 		11BC3C3A2A0DF62300410F63 /* AudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BC3C392A0DF62300410F63 /* AudioManager.swift */; };
 		11BF13972E42D32E00728799 /* CreatePlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BF13952E42D32E00728799 /* CreatePlaylistView.swift */; };
@@ -393,6 +395,7 @@
 		11AFC3182BE9ED7700602604 /* CreatureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatureManager.swift; sourceTree = "<group>"; };
 		11B048872EB842B3001B73C5 /* LipSyncUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LipSyncUtilities.swift; sourceTree = "<group>"; };
 		11B0488B2EB8430E001B73C5 /* ProcessingOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessingOverlayView.swift; sourceTree = "<group>"; };
+		FEA1A1E70000000000000001 /* ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlert.swift; sourceTree = "<group>"; };
 		11B9F1A72A0DDC5800F6C00A /* Creature_Console.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Creature_Console.entitlements; sourceTree = "<group>"; };
 		11BC3C392A0DF62300410F63 /* AudioManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManager.swift; sourceTree = "<group>"; };
 		11BF13952E42D32E00728799 /* CreatePlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePlaylistView.swift; sourceTree = "<group>"; };
@@ -1053,6 +1056,7 @@
 			isa = PBXGroup;
 			children = (
 				11B0488B2EB8430E001B73C5 /* ProcessingOverlayView.swift */,
+				FEA1A1E70000000000000001 /* ErrorAlert.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1678,6 +1682,7 @@
 				110C412C2E516F270079CA75 /* EmergencyStopMessageProcessor.swift in Sources */,
 				1199D6BF2BF5C4EA004E0D64 /* ServerLogItemProcessor.swift in Sources */,
 				11B0488D2EB8430E001B73C5 /* ProcessingOverlayView.swift in Sources */,
+				FEA1A1E70000000000000002 /* ErrorAlert.swift in Sources */,
 				11AFC3192BE9ED7700602604 /* CreatureManager.swift in Sources */,
 				1142E66229DFB22300B795F0 /* CreatureDetail.swift in Sources */,
 				11703D8C29DD197F00EF7E3D /* CreatureConsole.swift in Sources */,
@@ -1773,6 +1778,7 @@
 				11C54A4B2E91A1E0003CD966 /* StatusLightsState+UI.swift in Sources */,
 				11E53CD02E88A0C400C17F16 /* AppBootstrapper.swift in Sources */,
 				11B0488E2EB8430E001B73C5 /* ProcessingOverlayView.swift in Sources */,
+				FEA1A1E70000000000000003 /* ErrorAlert.swift in Sources */,
 				117C876F2CA0D45E007B5682 /* BottomToolBarView.swift in Sources */,
 				117C87702CA0D586007B5682 /* NetworkSettingsView.swift in Sources */,
 				11C7F0AA2F2A6D2C009A1B2C /* HideBottomToolbarPreferenceKey.swift in Sources */,
@@ -2039,7 +2045,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.34.2;
+				MARKETING_VERSION = 2.34.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -2093,7 +2099,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.34.2;
+				MARKETING_VERSION = 2.34.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2177,7 +2183,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.34.2;
+				MARKETING_VERSION = 2.34.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -2209,7 +2215,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.34.2;
+				MARKETING_VERSION = 2.34.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;

--- a/Sources/Creature Console/View/Dialog/DialogPreviewPanel.swift
+++ b/Sources/Creature Console/View/Dialog/DialogPreviewPanel.swift
@@ -33,8 +33,7 @@ struct DialogPreviewPanel: View {
     @State private var meta: DialogPreviewMetaDTO? = nil
     @State private var takes: [DialogPreviewLookupDTO.Generation] = []
 
-    @State private var showError = false
-    @State private var errorMessage = ""
+    @State private var errorAlert: ErrorAlert?
 
     // Export state (cross-platform via .fileExporter)
     @State private var exportData: Data? = nil
@@ -145,11 +144,7 @@ struct DialogPreviewPanel: View {
             takes = []
             statusMessage = nil
         }
-        .alert("Preview Error", isPresented: $showError) {
-            Button("OK") {}
-        } message: {
-            Text(errorMessage)
-        }
+        .errorAlert($errorAlert)
         .fileExporter(
             isPresented: $showExporter,
             document: AudioFileDocument(data: exportData ?? Data()),
@@ -458,8 +453,7 @@ struct DialogPreviewPanel: View {
     }
 
     private func presentError(_ message: String) {
-        errorMessage = message
-        showError = true
+        errorAlert = ErrorAlert(title: "Preview Error", message: message)
         statusMessage = nil
     }
 

--- a/Sources/Creature Console/View/Dialog/DialogRenderPanel.swift
+++ b/Sources/Creature Console/View/Dialog/DialogRenderPanel.swift
@@ -33,8 +33,7 @@ struct DialogRenderPanel: View {
     @State private var isSubmitting = false
 
     @State private var completedResult: DialogJobResult? = nil
-    @State private var showError = false
-    @State private var errorMessage = ""
+    @State private var errorAlert: ErrorAlert?
     @State private var renderedSoundToShare: String? = nil
 
     private var turnsAreReady: Bool {
@@ -109,11 +108,7 @@ struct DialogRenderPanel: View {
             if titleText.isEmpty { titleText = defaultTitle }
         }
         .shareableSoundFlow(fileName: $renderedSoundToShare)
-        .alert("Render Error", isPresented: $showError) {
-            Button("OK") {}
-        } message: {
-            Text(errorMessage)
-        }
+        .errorAlert($errorAlert)
         .task(id: activeJobId) {
             jobEventsTask?.cancel()
             guard let jobId = activeJobId else { return }
@@ -215,7 +210,7 @@ struct DialogRenderPanel: View {
                     }
                     activeJobId = job.jobId
                 case .failure(let error):
-                    presentError(ServerError.detailedMessage(from: error))
+                    errorAlert = ErrorAlert(title: "Render Error", error: error)
                 }
             }
         }
@@ -230,7 +225,9 @@ struct DialogRenderPanel: View {
             CacheInvalidationProcessor.rebuildAnimationCache(deleteStaleEntries: true)
             CacheInvalidationProcessor.rebuildSoundListCache(deleteStaleEntries: true)
         case .failed:
-            presentError(info.result ?? "The dialog render failed on the server.")
+            errorAlert = ErrorAlert(
+                title: "Render Error",
+                message: info.result ?? "The dialog render failed on the server.")
         default:
             break
         }
@@ -249,20 +246,17 @@ struct DialogRenderPanel: View {
                 switch animationResult {
                 case .success(let animation):
                     if animation.metadata.soundFile.isEmpty {
-                        presentError("This animation doesn't have a sound file to share.")
+                        errorAlert = ErrorAlert(
+                            title: "Render Error",
+                            message: "This animation doesn't have a sound file to share.")
                     } else {
                         renderedSoundToShare = animation.metadata.soundFile
                     }
                 case .failure(let error):
-                    presentError(ServerError.detailedMessage(from: error))
+                    errorAlert = ErrorAlert(title: "Render Error", error: error)
                 }
             }
         }
-    }
-
-    private func presentError(_ message: String) {
-        errorMessage = message
-        showError = true
     }
 
     private func formatDuration(_ seconds: Double) -> String {

--- a/Sources/Creature Console/View/LiveMagic/AdHocAssetsView.swift
+++ b/Sources/Creature Console/View/LiveMagic/AdHocAssetsView.swift
@@ -40,7 +40,7 @@ struct AdHocAnimationListView: View {
 
     @State private var animations: [AdHocAnimationSummary] = []
     @State private var isLoading = false
-    @State private var errorMessage: String?
+    @State private var errorAlert: ErrorAlert?
     @PlaylistResumePreference private var resumePlaylistAfterPlayback: Bool
     @State private var playingAnimationId: AnimationIdentifier?
     @State private var playTask: Task<Void, Never>?
@@ -113,17 +113,7 @@ struct AdHocAnimationListView: View {
             playTask?.cancel()
             playTask = nil
         }
-        .alert(
-            "Unable to Load",
-            isPresented: Binding(
-                get: { errorMessage != nil },
-                set: { if !$0 { errorMessage = nil } }
-            )
-        ) {
-            Button("OK", role: .cancel) { errorMessage = nil }
-        } message: {
-            Text(errorMessage ?? "")
-        }
+        .errorAlert($errorAlert)
     }
 
     private func triggerPlayback(for animationId: AnimationIdentifier) {
@@ -147,9 +137,9 @@ struct AdHocAnimationListView: View {
             playTask = nil
             switch result {
             case .success:
-                errorMessage = nil
+                errorAlert = nil
             case .failure(let error):
-                errorMessage = ServerError.detailedMessage(from: error)
+                errorAlert = ErrorAlert(title: "Unable to Load", error: error)
             }
         }
     }
@@ -163,9 +153,9 @@ struct AdHocAnimationListView: View {
             switch result {
             case .success(let list):
                 animations = list
-                errorMessage = nil
+                errorAlert = nil
             case .failure(let error):
-                errorMessage = ServerError.detailedMessage(from: error)
+                errorAlert = ErrorAlert(title: "Unable to Load", error: error)
             }
         }
     }
@@ -364,12 +354,9 @@ struct AdHocSoundListView: View {
 
     @State private var sounds: [AdHocSoundEntry] = []
     @State private var isLoading = false
-    @State private var errorMessage: String?
+    @State private var errorAlert: ErrorAlert?
     @State private var preparingSound: String?
     @State private var playTask: Task<Void, Never>?
-    @State private var alertTitle: String = ""
-    @State private var alertMessage: String = ""
-    @State private var showAlert: Bool = false
     @State private var soundToShare: String? = nil
 
     var body: some View {
@@ -419,17 +406,7 @@ struct AdHocSoundListView: View {
         .task {
             await load()
         }
-        .alert(
-            "Unable to Load",
-            isPresented: Binding(
-                get: { errorMessage != nil },
-                set: { if !$0 { errorMessage = nil } }
-            )
-        ) {
-            Button("OK", role: .cancel) { errorMessage = nil }
-        } message: {
-            Text(errorMessage ?? "")
-        }
+        .errorAlert($errorAlert)
     }
 
     private func load(force: Bool = false) async {
@@ -441,9 +418,9 @@ struct AdHocSoundListView: View {
             switch result {
             case .success(let list):
                 sounds = list
-                errorMessage = nil
+                errorAlert = nil
             case .failure(let error):
-                errorMessage = ServerError.detailedMessage(from: error)
+                errorAlert = ErrorAlert(title: "Unable to Load", error: error)
             }
         }
     }
@@ -484,9 +461,7 @@ struct AdHocSoundListView: View {
 
     private func presentError(_ title: String, message: String) async {
         await MainActor.run {
-            alertTitle = title
-            alertMessage = message
-            showAlert = true
+            errorAlert = ErrorAlert(title: title, message: message)
             preparingSound = nil
         }
     }

--- a/Sources/Creature Console/View/Shared/ErrorAlert.swift
+++ b/Sources/Creature Console/View/Shared/ErrorAlert.swift
@@ -1,0 +1,59 @@
+import Common
+import SwiftUI
+
+/// A presentable error alert — an optional title plus a message — backing the shared
+/// `.errorAlert(_:)` modifier.
+///
+/// This replaces the per-view `showError` / `errorMessage` / `presentError(...)` triads
+/// that were copy-pasted across ~two dozen views, along with the near-identical
+/// `AlertDescriptor` / `TVAlertDescriptor` value types (issue #8). Build one from a thrown
+/// error and it preserves the server's detailed message automatically:
+///
+/// ```swift
+/// @State private var errorAlert: ErrorAlert?
+/// // ...
+/// .errorAlert($errorAlert)
+/// // ...
+/// errorAlert = ErrorAlert(title: "Render Error", error: error)
+/// ```
+struct ErrorAlert: Identifiable {
+    let id = UUID()
+    var title: String
+    var message: String
+
+    init(title: String = "Error", message: String) {
+        self.title = title
+        self.message = message
+    }
+
+    /// Build from any thrown error, preserving the server's detailed message rather than
+    /// the lossy `localizedDescription`.
+    init(title: String = "Error", error: any Error) {
+        self.init(title: title, message: ServerError.detailedMessage(from: error))
+    }
+}
+
+extension View {
+    /// Presents `error` as a single-button ("OK") alert whenever it becomes non-nil,
+    /// clearing it back to `nil` on dismiss. Uses the modern
+    /// `alert(_:isPresented:presenting:)` API rather than the deprecated `Alert` type.
+    ///
+    /// - Parameter onDismiss: optional side effect to run when the alert is dismissed
+    ///   (e.g. resetting a trigger binding so the same action can fire again).
+    func errorAlert(_ error: Binding<ErrorAlert?>, onDismiss: @escaping () -> Void = {})
+        -> some View
+    {
+        alert(
+            error.wrappedValue?.title ?? "Error",
+            isPresented: Binding(
+                get: { error.wrappedValue != nil },
+                set: { presented in if !presented { error.wrappedValue = nil } }
+            ),
+            presenting: error.wrappedValue
+        ) { _ in
+            Button("OK", role: .cancel) { onDismiss() }
+        } message: { alert in
+            Text(alert.message)
+        }
+    }
+}

--- a/Sources/Creature Console/View/Sounds/ShareableSoundButton.swift
+++ b/Sources/Creature Console/View/Sounds/ShareableSoundButton.swift
@@ -24,8 +24,7 @@ import UniformTypeIdentifiers
         @State private var exportData: Data? = nil
         @State private var exportFilename = "sound.ogg"
         @State private var showExporter = false
-        @State private var showError = false
-        @State private var errorMessage = ""
+        @State private var errorAlert: ErrorAlert?
 
         func body(content: Content) -> some View {
             content
@@ -43,16 +42,14 @@ import UniformTypeIdentifiers
                     case .success(let url):
                         logger.info("saved shareable sound to \(url.path)")
                     case .failure(let error):
-                        presentError("Export failed: \(error.localizedDescription)")
+                        errorAlert = ErrorAlert(
+                            title: "Sharing Failed",
+                            message: "Export failed: \(error.localizedDescription)")
                     }
                     exportData = nil
                     fileName = nil
                 }
-                .alert("Sharing Failed", isPresented: $showError) {
-                    Button("OK") { fileName = nil }
-                } message: {
-                    Text(errorMessage)
-                }
+                .errorAlert($errorAlert) { fileName = nil }
         }
 
         private func download(_ name: String) {
@@ -68,15 +65,10 @@ import UniformTypeIdentifiers
                         exportFilename = shareable.suggestedFilename
                         showExporter = true
                     case .failure(let error):
-                        presentError(ServerError.detailedMessage(from: error))
+                        errorAlert = ErrorAlert(title: "Sharing Failed", error: error)
                     }
                 }
             }
-        }
-
-        private func presentError(_ message: String) {
-            errorMessage = message
-            showError = true
         }
     }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+creature-cli (2.34.3) unstable; urgency=medium
+
+  * No CLI changes — version bump to stay in lockstep with the Console app,
+    which consolidates the copy-pasted error-alert plumbing behind a shared
+    ErrorAlert value + .errorAlert(_:) modifier (DRY audit, issue #8).
+
+ -- April White <april@creature.engineering>  Fri, 03 Jul 2026 00:00:00 +0000
+
 creature-cli (2.34.2) unstable; urgency=medium
 
   * No CLI changes — version bump to stay in lockstep with the Console app,


### PR DESCRIPTION
First implementation PR for the console DRY audit (#8), tackling **finding #2** — the `showError` / `errorMessage` / `.alert` / `presentError` triad copy-pasted across the app, each site re-calling `ServerError.detailedMessage(from:)` and drifting apart.

## What changed
- **New `View/Shared/ErrorAlert.swift`** — an `ErrorAlert` value (`title` + `message`, plus an `error:` convenience init that folds in `ServerError.detailedMessage`) and a modern `.errorAlert(_:)` view modifier (uses `alert(_:isPresented:presenting:)`, not the deprecated `Alert` type; optional `onDismiss` for trigger-reset side effects like `ShareableSoundButton`'s `fileName = nil`).
- **Migrated:** `ShareableSoundButton`, `DialogRenderPanel`, `DialogPreviewPanel`, `AdHocAssetsView` (both list sub-views). Net **−130 lines** of triad boilerplate in the views.
- **Latent bug fixed:** `AdHocSoundListView`'s playback errors set an `alertTitle`/`alertMessage`/`showAlert` triad with **no `.alert` bound to it** — those errors were silently swallowed. They now surface through the shared facade.

## Scope notes
- Findings **#1** (job observation via `events(forJob:)`) and **#3** (`seedQueued`) were already done by an earlier commit — verified, nothing to do.
- `LiveMagicViewModel`'s `AlertDescriptor` is a **general** alert (used for success like "Cue Sent"), so it's deliberately *not* forced into an error-named type — that's finding **#5**, a follow-up.
- Deferred to follow-up PRs: **#5** general alert dedup, the **tvOS** error alerts, **#4** URL-guard boilerplate (Common — needs Linux re-verify), **#6** duplicate formatters.

## Verification
- Builds clean on **macOS, iOS, and tvOS** (the facade + `AdHocAssetsView` are cross-platform; `ErrorAlert.swift` registered in both app and Creature TV targets).
- `Common` test suite: 342 passing.
- `swift build` (root SPM `CreatureConsole` target) green; `pbxproj` lints clean.

Refs #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)