### PR TITLE
DRY #8: migrate tvOS error alerts to ErrorAlert (resolves #5)

### DIFF
--- a/Common/Sources/CreatureCLI/top.swift
+++ b/Common/Sources/CreatureCLI/top.swift
@@ -35,7 +35,7 @@ struct CreatureCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for interacting with the Creature Server",
         discussion: "A tool for interacting and testing the Creature Server from the command line",
-        version: "2.34.3",
+        version: "2.34.4",
         subcommands: [
             Animations.self, Creatures.self, Debug.self, Dialog.self, Fixtures.self, Metrics.self,
             Network.self, Playlists.self, Sounds.self, Storyboards.self, Util.self, Voice.self,

--- a/Creature Console.xcodeproj/project.pbxproj
+++ b/Creature Console.xcodeproj/project.pbxproj
@@ -2045,7 +2045,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.34.3;
+				MARKETING_VERSION = 2.34.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -2099,7 +2099,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.34.3;
+				MARKETING_VERSION = 2.34.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2183,7 +2183,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.34.3;
+				MARKETING_VERSION = 2.34.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -2215,7 +2215,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.34.3;
+				MARKETING_VERSION = 2.34.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;

--- a/Sources/Creature Console/View/Shared/ErrorAlert.swift
+++ b/Sources/Creature Console/View/Shared/ErrorAlert.swift
@@ -5,8 +5,8 @@ import SwiftUI
 /// `.errorAlert(_:)` modifier.
 ///
 /// This replaces the per-view `showError` / `errorMessage` / `presentError(...)` triads
-/// that were copy-pasted across ~two dozen views, along with the near-identical
-/// `AlertDescriptor` / `TVAlertDescriptor` value types (issue #8). Build one from a thrown
+/// that were copy-pasted across ~two dozen views, along with the tvOS `TVAlertDescriptor`
+/// value type (issue #8). Build one from a thrown
 /// error and it preserves the server's detailed message automatically:
 ///
 /// ```swift

--- a/Sources/Creature Console/View/tvOS/TVAnimationTriggerView.swift
+++ b/Sources/Creature Console/View/tvOS/TVAnimationTriggerView.swift
@@ -20,7 +20,7 @@
         @State private var isRefreshing = false
         @State private var pendingAction: PendingAction?
         @State private var resumePreferences: [AnimationIdentifier: Bool] = [:]
-        @State private var alertDescriptor: TVAlertDescriptor?
+        @State private var errorAlert: ErrorAlert?
         @State private var toast: TVStatusToast?
         @State private var toastTask: Task<Void, Never>?
 
@@ -77,13 +77,7 @@
             }
             .animation(.easeInOut(duration: 0.35), value: isRefreshing)
             .animation(.easeInOut(duration: 0.35), value: toast)
-            .alert(item: $alertDescriptor) { descriptor in
-                Alert(
-                    title: Text(descriptor.title),
-                    message: Text(descriptor.message),
-                    dismissButton: .default(Text("OK"))
-                )
-            }
+            .errorAlert($errorAlert)
             .task {
                 await refresh()
             }
@@ -333,7 +327,7 @@
 
         @MainActor
         private func presentError(_ title: String, message: String) {
-            alertDescriptor = TVAlertDescriptor(title: title, message: message)
+            errorAlert = ErrorAlert(title: title, message: message)
         }
 
         @MainActor

--- a/Sources/Creature Console/View/tvOS/TVSoundboardView.swift
+++ b/Sources/Creature Console/View/tvOS/TVSoundboardView.swift
@@ -17,7 +17,7 @@
 
         @State private var isRefreshing = false
         @State private var pendingSoundId: SoundIdentifier?
-        @State private var alertDescriptor: TVAlertDescriptor?
+        @State private var errorAlert: ErrorAlert?
         @State private var toast: TVStatusToast?
         @State private var toastTask: Task<Void, Never>?
 
@@ -73,13 +73,7 @@
             }
             .animation(.easeInOut(duration: 0.35), value: isRefreshing)
             .animation(.easeInOut(duration: 0.35), value: toast)
-            .alert(item: $alertDescriptor) { descriptor in
-                Alert(
-                    title: Text(descriptor.title),
-                    message: Text(descriptor.message),
-                    dismissButton: .default(Text("OK"))
-                )
-            }
+            .errorAlert($errorAlert)
             .task {
                 await refresh()
             }
@@ -291,7 +285,7 @@
 
         @MainActor
         private func presentError(_ title: String, message: String) {
-            alertDescriptor = TVAlertDescriptor(title: title, message: message)
+            errorAlert = ErrorAlert(title: title, message: message)
         }
 
         @MainActor

--- a/Sources/Creature Console/View/tvOS/TVUserFeedback.swift
+++ b/Sources/Creature Console/View/tvOS/TVUserFeedback.swift
@@ -1,12 +1,6 @@
 #if os(tvOS)
     import SwiftUI
 
-    struct TVAlertDescriptor: Identifiable {
-        let id = UUID()
-        let title: String
-        let message: String
-    }
-
     struct TVStatusToast: Identifiable, Equatable {
         enum Kind {
             case success

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+creature-cli (2.34.4) unstable; urgency=medium
+
+  * No CLI changes — version bump to stay in lockstep with the Console app,
+    which finishes the tvOS half of the error-alert consolidation: the tvOS
+    soundboard and animation-trigger views now use the shared ErrorAlert
+    facade, the duplicate TVAlertDescriptor type is gone, and those alerts move
+    off the deprecated Alert API (DRY audit, issue #8).
+
+ -- April White <april@creature.engineering>  Fri, 03 Jul 2026 00:00:00 +0000
+
 creature-cli (2.34.3) unstable; urgency=medium
 
   * No CLI changes — version bump to stay in lockstep with the Console app,


### PR DESCRIPTION
Follow-up to #16, finishing the **tvOS** half of finding #2 and resolving finding **#5**.

## What changed
- `TVSoundboardView` and `TVAnimationTriggerView` each hand-rolled a `TVAlertDescriptor` + `.alert(item:) { Alert(...) }` + `presentError` triad — the twin of LiveMagic's `AlertDescriptor` that finding #5 flagged. Both now use the shared `ErrorAlert` / `.errorAlert(_:)` facade from #16.
- **Deleted `TVAlertDescriptor`.** It was errors-only (tvOS success feedback goes through the separate `TVStatusToast`), so the swap is clean. This also moves those alerts **off the deprecated `Alert` type** onto `alert(_:isPresented:presenting:)`.

## Resolves #5
With `TVAlertDescriptor` gone, LiveMagic's `AlertDescriptor` is no longer duplicated — it's a legitimately *general* (success + error) alert type, so it's left as-is. The "two near-identical structs" duplication is eliminated.

## Verification
- Builds clean on **tvOS** (Apple TV 4K sim); SPM/macOS build green.
- Net −8 lines; alerts modernized off the deprecated API.

## Remaining on #8
- **#4** URL-guard boilerplate (63 Common methods; needs Linux re-verify)
- **#6** duplicate formatters (`formatDuration` ×2, `formatMillis` ×2)
- **#7/#8** parallel lip-sync handlers + cache-rebuild pair (largely collapse once the above land)

Refs #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)