### PR TITLE
DRY #8: shared TimeHelper formatters (finding #6)

### DIFF
--- a/Common/Sources/Common/TimeHelper.swift
+++ b/Common/Sources/Common/TimeHelper.swift
@@ -17,4 +17,25 @@ public struct TimeHelper {
         return formatter.string(from: date)
     }
 
+    /// Formats a number of seconds as a clock-style `M:SS` duration (e.g. `75` → `"1:15"`).
+    public static func formatDuration(_ seconds: Double) -> String {
+        let total = Int(seconds.rounded())
+        return String(format: "%d:%02d", total / 60, total % 60)
+    }
+
+    /// A configured, reused formatter for `formatEpochMillis`. `DateFormatter` is expensive
+    /// to build; reading a configured instance is safe to share.
+    private static let epochMillisFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+        return formatter
+    }()
+
+    /// Formats Unix epoch milliseconds as `yyyy-MM-dd HH:mm`, or `"—"` when `nil`.
+    public static func formatEpochMillis(_ millis: Int64?) -> String {
+        guard let millis else { return "—" }
+        let date = Date(timeIntervalSince1970: Double(millis) / 1000.0)
+        return epochMillisFormatter.string(from: date)
+    }
+
 }

--- a/Common/Sources/CreatureCLI/dialogCommand.swift
+++ b/Common/Sources/CreatureCLI/dialogCommand.swift
@@ -46,7 +46,7 @@ extension CreatureCLI {
                                     title: "Turns", valueProvider: { String($0.turns.count) }),
                                 TableColumn(
                                     title: "Updated",
-                                    valueProvider: { formatMillis($0.updatedAt) }),
+                                    valueProvider: { TimeHelper.formatEpochMillis($0.updatedAt) }),
                             ])
                         print(
                             "\n\(scripts.count) script(s) on server at \(server.serverHostname)\n")
@@ -516,14 +516,6 @@ private func writeWav(_ data: Data, to path: String) throws {
     }
 }
 
-private func formatMillis(_ millis: Int64?) -> String {
-    guard let millis else { return "—" }
-    let date = Date(timeIntervalSince1970: Double(millis) / 1000.0)
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd HH:mm"
-    return formatter.string(from: date)
-}
-
 private func dialogScriptDetails(_ script: DialogScript) -> String {
     var lines: [String] = []
     lines.append("Title:    \(script.title)")
@@ -531,8 +523,8 @@ private func dialogScriptDetails(_ script: DialogScript) -> String {
     if !script.notes.isEmpty {
         lines.append("Notes:    \(script.notes)")
     }
-    lines.append("Created:  \(formatMillis(script.createdAt))")
-    lines.append("Updated:  \(formatMillis(script.updatedAt))")
+    lines.append("Created:  \(TimeHelper.formatEpochMillis(script.createdAt))")
+    lines.append("Updated:  \(TimeHelper.formatEpochMillis(script.updatedAt))")
     lines.append("Turns:    \(script.turns.count)")
     lines.append("")
     for (index, turn) in script.turns.enumerated() {

--- a/Common/Sources/CreatureCLI/storyboardCommand.swift
+++ b/Common/Sources/CreatureCLI/storyboardCommand.swift
@@ -47,7 +47,7 @@ extension CreatureCLI {
                                     title: "Tiles", valueProvider: { String($0.tiles.count) }),
                                 TableColumn(
                                     title: "Updated",
-                                    valueProvider: { formatMillis($0.updatedAt) }),
+                                    valueProvider: { TimeHelper.formatEpochMillis($0.updatedAt) }),
                             ])
                         print(
                             "\n\(boards.count) storyboard(s) on server at \(server.serverHostname)\n"
@@ -391,14 +391,6 @@ private func readFileData(at path: String) throws -> Data {
     }
 }
 
-private func formatMillis(_ millis: Int64?) -> String {
-    guard let millis else { return "—" }
-    let date = Date(timeIntervalSince1970: Double(millis) / 1000.0)
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd HH:mm"
-    return formatter.string(from: date)
-}
-
 private func storyboardDetails(_ board: Storyboard) -> String {
     var lines: [String] = []
     lines.append("Title:    \(board.title.isEmpty ? "(untitled)" : board.title)")
@@ -406,8 +398,8 @@ private func storyboardDetails(_ board: Storyboard) -> String {
     if !board.notes.isEmpty {
         lines.append("Notes:    \(board.notes)")
     }
-    lines.append("Created:  \(formatMillis(board.createdAt))")
-    lines.append("Updated:  \(formatMillis(board.updatedAt))")
+    lines.append("Created:  \(TimeHelper.formatEpochMillis(board.createdAt))")
+    lines.append("Updated:  \(TimeHelper.formatEpochMillis(board.updatedAt))")
     lines.append("Tiles:    \(board.tiles.count)")
     lines.append("")
     for (index, tile) in board.tiles.enumerated() {

--- a/Common/Sources/CreatureCLI/top.swift
+++ b/Common/Sources/CreatureCLI/top.swift
@@ -35,7 +35,7 @@ struct CreatureCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for interacting with the Creature Server",
         discussion: "A tool for interacting and testing the Creature Server from the command line",
-        version: "2.34.4",
+        version: "2.34.5",
         subcommands: [
             Animations.self, Creatures.self, Debug.self, Dialog.self, Fixtures.self, Metrics.self,
             Network.self, Playlists.self, Sounds.self, Storyboards.self, Util.self, Voice.self,

--- a/Creature Console.xcodeproj/project.pbxproj
+++ b/Creature Console.xcodeproj/project.pbxproj
@@ -2045,7 +2045,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.34.4;
+				MARKETING_VERSION = 2.34.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -2099,7 +2099,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.34.4;
+				MARKETING_VERSION = 2.34.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2183,7 +2183,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.34.4;
+				MARKETING_VERSION = 2.34.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -2215,7 +2215,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.34.4;
+				MARKETING_VERSION = 2.34.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;

--- a/Sources/Creature Console/View/Dialog/DialogPreviewPanel.swift
+++ b/Sources/Creature Console/View/Dialog/DialogPreviewPanel.swift
@@ -95,7 +95,7 @@ struct DialogPreviewPanel: View {
                     Image(systemName: meta.cached ? "bolt.fill" : "sparkles")
                         .foregroundStyle(meta.cached ? .yellow : .blue)
                     Text(
-                        "\(meta.cached ? "Cached take" : "Fresh take") • \(formatDuration(meta.durationSeconds))"
+                        "\(meta.cached ? "Cached take" : "Fresh take") • \(TimeHelper.formatDuration(meta.durationSeconds))"
                     )
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -455,11 +455,6 @@ struct DialogPreviewPanel: View {
     private func presentError(_ message: String) {
         errorAlert = ErrorAlert(title: "Preview Error", message: message)
         statusMessage = nil
-    }
-
-    private func formatDuration(_ seconds: Double) -> String {
-        let total = Int(seconds.rounded())
-        return String(format: "%d:%02d", total / 60, total % 60)
     }
 
     private func takeLabel(_ take: DialogPreviewLookupDTO.Generation, index: Int) -> String {

--- a/Sources/Creature Console/View/Dialog/DialogRenderPanel.swift
+++ b/Sources/Creature Console/View/Dialog/DialogRenderPanel.swift
@@ -141,7 +141,7 @@ struct DialogRenderPanel: View {
                 .foregroundStyle(.green)
                 .font(.subheadline.bold())
             Text(
-                "\(result.numberOfFrames) frames • \(formatDuration(result.durationSeconds)) • \(result.persistence)"
+                "\(result.numberOfFrames) frames • \(TimeHelper.formatDuration(result.durationSeconds)) • \(result.persistence)"
                     + (result.autoplayed ? " • autoplayed" : "")
             )
             .font(.caption)
@@ -257,11 +257,6 @@ struct DialogRenderPanel: View {
                 }
             }
         }
-    }
-
-    private func formatDuration(_ seconds: Double) -> String {
-        let total = Int(seconds.rounded())
-        return String(format: "%d:%02d", total / 60, total % 60)
     }
 
     private func progressMilestone(_ progress: Double?) -> String {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+creature-cli (2.34.5) unstable; urgency=medium
+
+  * Internal refactor (no behavior change): the duplicated `formatMillis` date
+    formatter in the dialog and storyboard commands is now the shared
+    `TimeHelper.formatEpochMillis` (with a cached DateFormatter), alongside a
+    shared `TimeHelper.formatDuration` used by the app's dialog panels (DRY
+    audit, issue #8).
+
+ -- April White <april@creature.engineering>  Fri, 03 Jul 2026 00:00:00 +0000
+
 creature-cli (2.34.4) unstable; urgency=medium
 
   * No CLI changes — version bump to stay in lockstep with the Console app,


### PR DESCRIPTION
Finding **#6** of the console DRY audit (#8): duplicated date/duration formatters.

## What changed
- `formatDuration` (seconds → `"M:SS"`) was byte-identical in `DialogRenderPanel` and `DialogPreviewPanel`.
- `formatMillis` (epoch millis → `"yyyy-MM-dd HH:mm"`) was byte-identical in the `dialog` and `storyboard` CLI commands, **allocating a fresh `DateFormatter` on every call**.

Both now live in `Common/TimeHelper.swift` as `TimeHelper.formatDuration(_:)` and `TimeHelper.formatEpochMillis(_:)` — the latter backed by a **single cached `DateFormatter`**. All four call sites route through them. No behavior change.

## Verification
- App (SPM `CreatureConsole` target) + `creature-cli` build green.
- `Common` test suite: 342 passing.
- **Linux**: `creature-cli`, `creature-mqtt`, `creature-agent` all build in the `swift:6.3.2` container (Common changed).

Refs #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)