### PR TITLE
DRY #8: fold REST URL-guard boilerplate into path: overloads (finding #4)

### DIFF
--- a/Common/Sources/Common/Controller/Server/CreatureServerClient.swift
+++ b/Common/Sources/Common/Controller/Server/CreatureServerClient.swift
@@ -234,6 +234,66 @@ public final class CreatureServerClient: CreatureServerClientProtocol, Sendable 
         }
     }
 
+    // MARK: - Path-based overloads
+    //
+    // Every REST method used to hand-roll the same three lines: build the URL from the HTTP
+    // base + a path, `guard` it (returning the same "unable to make base URL" failure), and
+    // log it. These overloads own that so callers just pass a `path:`.
+
+    /// Builds the REST URL for `path` against the HTTP base, or `nil` if the result isn't a
+    /// valid URL.
+    func makeURL(_ path: String) -> URL? {
+        URL(string: makeBaseURL(.http) + path)
+    }
+
+    func fetchData<T: Decodable>(path: String, returnType: T.Type) async -> Result<T, ServerError> {
+        guard let url = makeURL(path) else {
+            return .failure(.serverError("unable to make base URL"))
+        }
+        logger.debug("Using URL: \(url)")
+        return await fetchData(url, returnType: returnType)
+    }
+
+    func fetchDataResponse(path: String) async -> Result<HTTPResponseData, ServerError> {
+        guard let url = makeURL(path) else {
+            return .failure(.serverError("unable to make base URL"))
+        }
+        logger.debug("Using URL: \(url)")
+        return await fetchDataResponse(url)
+    }
+
+    func sendData<T: Decodable, U: Encodable>(
+        path: String, method: String = "POST", body: U, returnType: T.Type
+    ) async -> Result<T, ServerError> {
+        guard let url = makeURL(path) else {
+            return .failure(.serverError("unable to make base URL"))
+        }
+        logger.debug("Using URL: \(url)")
+        return await sendData(url, method: method, body: body, returnType: returnType)
+    }
+
+    func sendDataResponse<U: Encodable>(
+        path: String, method: String = "POST", body: U,
+        successStatusCodes: Set<Int> = [200, 201, 202]
+    ) async -> Result<HTTPResponseData, ServerError> {
+        guard let url = makeURL(path) else {
+            return .failure(.serverError("unable to make base URL"))
+        }
+        logger.debug("Using URL: \(url)")
+        return await sendDataResponse(
+            url, method: method, body: body, successStatusCodes: successStatusCodes)
+    }
+
+    func sendRawJson<T: Decodable>(
+        path: String, method: String = "POST", rawJson: String, returnType: T.Type
+    ) async -> Result<T, ServerError> {
+        guard let url = makeURL(path) else {
+            return .failure(.serverError("unable to make base URL"))
+        }
+        logger.debug("Using URL: \(url)")
+        return await sendRawJson(url, method: method, rawJson: rawJson, returnType: returnType)
+    }
+
     func fetchDataResponse(_ url: URL) async -> Result<HTTPResponseData, ServerError> {
         var request = createConfiguredURLRequest(for: url)
         // Never serve these REST reads from the URL cache. The server doesn't send

--- a/Common/Sources/Common/Controller/Server/RESTful/AnimationMethods.swift
+++ b/Common/Sources/Common/Controller/Server/RESTful/AnimationMethods.swift
@@ -13,16 +13,12 @@ extension CreatureServerClient {
         logger.debug(
             "attempting to play an already-stored animation \(animationId) on universe \(universe)")
 
-        // Construct the URL
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/play") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let requestBody = PlayAnimationRequestDto(animation_id: animationId, universe: universe)
 
-        return await sendData(url, method: "POST", body: requestBody, returnType: StatusDTO.self)
-            .map { $0.message }
+        return await sendData(
+            path: "/animation/play", method: "POST", body: requestBody, returnType: StatusDTO.self
+        )
+        .map { $0.message }
     }
 
     public func interruptWithAnimation(
@@ -33,17 +29,14 @@ extension CreatureServerClient {
             "attempting to interrupt with animation \(animationId) on universe \(universe), resumePlaylist: \(resumePlaylist)"
         )
 
-        // Construct the URL
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/interrupt") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let requestBody = PlayAnimationRequestDto(
             animation_id: animationId, universe: universe, resumePlaylist: resumePlaylist)
 
-        return await sendData(url, method: "POST", body: requestBody, returnType: StatusDTO.self)
-            .map { $0.message }
+        return await sendData(
+            path: "/animation/interrupt", method: "POST", body: requestBody,
+            returnType: StatusDTO.self
+        )
+        .map { $0.message }
     }
 
 
@@ -51,15 +44,9 @@ extension CreatureServerClient {
 
         logger.debug("attempting to save animation \(animation.metadata.title) on server")
 
-        // Construct the URL
-        guard let url = URL(string: makeBaseURL(.http) + "/animation") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         logger.debug("calling sendData() now...")
         let returnObject = await sendData(
-            url, method: "POST", body: animation, returnType: Animation.self)
+            path: "/animation", method: "POST", body: animation, returnType: Animation.self)
         logger.debug("...and we're back!")
 
         // Yay we got something back
@@ -84,12 +71,9 @@ extension CreatureServerClient {
             "attempting to get all of the animation metadatas"
         )
 
-        guard let url = URL(string: makeBaseURL(.http) + "/animation") else {
-            return .failure(.serverError("unable to make base URL"))
+        return await fetchData(path: "/animation", returnType: AnimationMetadataListDTO.self).map {
+            $0.items
         }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: AnimationMetadataListDTO.self).map { $0.items }
 
     }
 
@@ -99,12 +83,7 @@ extension CreatureServerClient {
 
         logger.debug("attempting to load animation \(animationId)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/\(animationId)") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: Animation.self)
+        return await fetchData(path: "/animation/\(animationId)", returnType: Animation.self)
     }
 
     public func deleteAnimation(animationId: AnimationIdentifier) async -> Result<
@@ -112,13 +91,11 @@ extension CreatureServerClient {
     > {
         logger.debug("attempting to delete animation \(animationId)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/\(animationId)") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await sendData(url, method: "DELETE", body: EmptyBody(), returnType: StatusDTO.self)
-            .map { $0.message }
+        return await sendData(
+            path: "/animation/\(animationId)", method: "DELETE", body: EmptyBody(),
+            returnType: StatusDTO.self
+        )
+        .map { $0.message }
     }
 
     public func generateLipSyncForAnimation(animationId: AnimationIdentifier)
@@ -127,15 +104,11 @@ extension CreatureServerClient {
 
         logger.debug("queue lip sync generation for animation \(animationId)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/generate-lipsync") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let requestBody = RegenerateLipSyncRequestDTO(animationId: animationId)
 
         return await sendData(
-            url, method: "POST", body: requestBody, returnType: JobCreatedResponse.self)
+            path: "/animation/generate-lipsync", method: "POST", body: requestBody,
+            returnType: JobCreatedResponse.self)
     }
 
     public func getAdHocAnimation(animationId: AnimationIdentifier) async -> Result<
@@ -144,37 +117,23 @@ extension CreatureServerClient {
 
         logger.debug("attempting to load ad-hoc animation \(animationId)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/ad-hoc/\(animationId)")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: Animation.self)
+        return await fetchData(path: "/animation/ad-hoc/\(animationId)", returnType: Animation.self)
     }
 
     public func listAdHocAnimations() async -> Result<[AdHocAnimationSummary], ServerError> {
 
         logger.debug("attempting to load ad-hoc animations")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/ad-hoc") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: AdHocAnimationListDTO.self).map { $0.items }
+        return await fetchData(path: "/animation/ad-hoc", returnType: AdHocAnimationListDTO.self)
+            .map { $0.items }
     }
 
     private func sendAdHocAnimationRequest(
         path: String, body: CreateAdHocAnimationRequestDTO
     ) async -> Result<JobCreatedResponse, ServerError> {
 
-        guard let url = URL(string: makeBaseURL(.http) + path) else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await sendData(url, method: "POST", body: body, returnType: JobCreatedResponse.self)
+        return await sendData(
+            path: path, method: "POST", body: body, returnType: JobCreatedResponse.self)
     }
 
     public func createAdHocSpeechAnimation(
@@ -199,54 +158,43 @@ extension CreatureServerClient {
     public func startStreamingAdHocSpeech(
         creatureId: CreatureIdentifier, resumePlaylist: Bool = true
     ) async -> Result<StreamingAdHocStartResponse, ServerError> {
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/ad-hoc-stream/start")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
         let body = StreamingAdHocStartRequest(
             creatureId: creatureId, resumePlaylist: resumePlaylist)
         return await sendData(
-            url, method: "POST", body: body, returnType: StreamingAdHocStartResponse.self)
+            path: "/animation/ad-hoc-stream/start", method: "POST", body: body,
+            returnType: StreamingAdHocStartResponse.self)
     }
 
     /// Add a text chunk (sentence) to an active streaming session.
     public func addStreamingAdHocText(
         sessionId: String, text: String
     ) async -> Result<StreamingAdHocTextResponse, ServerError> {
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/ad-hoc-stream/text")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
         let body = StreamingAdHocTextRequest(sessionId: sessionId, text: text)
         return await sendData(
-            url, method: "POST", body: body, returnType: StreamingAdHocTextResponse.self)
+            path: "/animation/ad-hoc-stream/text", method: "POST", body: body,
+            returnType: StreamingAdHocTextResponse.self)
     }
 
     /// Finish a streaming session — synthesizes speech, builds animation, plays it.
     public func finishStreamingAdHocSpeech(
         sessionId: String
     ) async -> Result<StreamingAdHocFinishResponse, ServerError> {
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/ad-hoc-stream/finish")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
         let body = StreamingAdHocFinishRequest(sessionId: sessionId)
         return await sendData(
-            url, method: "POST", body: body, returnType: StreamingAdHocFinishResponse.self)
+            path: "/animation/ad-hoc-stream/finish", method: "POST", body: body,
+            returnType: StreamingAdHocFinishResponse.self)
     }
 
     public func triggerPreparedAdHocSpeech(
         animationId: AnimationIdentifier, resumePlaylist: Bool = true
     ) async -> Result<String, ServerError> {
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/ad-hoc/play") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let requestBody = TriggerAdHocAnimationRequestDTO(
             animationId: animationId, resumePlaylist: resumePlaylist)
 
-        return await sendData(url, method: "POST", body: requestBody, returnType: StatusDTO.self)
-            .map { $0.message }
+        return await sendData(
+            path: "/animation/ad-hoc/play", method: "POST", body: requestBody,
+            returnType: StatusDTO.self
+        )
+        .map { $0.message }
     }
 }

--- a/Common/Sources/Common/Controller/Server/RESTful/CreatureMethods.swift
+++ b/Common/Sources/Common/Controller/Server/RESTful/CreatureMethods.swift
@@ -7,12 +7,7 @@ extension CreatureServerClient {
 
         logger.debug("attempting to get all of the creatures")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/creature") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: CreatureListDTO.self).map { $0.items }
+        return await fetchData(path: "/creature", returnType: CreatureListDTO.self).map { $0.items }
 
     }
 
@@ -24,12 +19,7 @@ extension CreatureServerClient {
     public func getCreature(creatureId: CreatureIdentifier) async throws -> Result<
         Creature, ServerError
     > {
-        guard let url = URL(string: makeBaseURL(.http) + "/creature/\(creatureId)") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: Creature.self)
+        return await fetchData(path: "/creature/\(creatureId)", returnType: Creature.self)
     }
 
     /// Fetches a creature's complete stored configuration as raw JSON, exactly as the
@@ -38,37 +28,26 @@ extension CreatureServerClient {
     /// view and would silently drop fields like motors and servo settings.
     public func exportCreature(creatureId: CreatureIdentifier) async -> Result<String, ServerError>
     {
-        guard let url = URL(string: makeBaseURL(.http) + "/creature/\(creatureId)/export") else {
-            return .failure(.serverError("unable to make base URL"))
+        return await fetchDataResponse(path: "/creature/\(creatureId)/export").map {
+            String(decoding: $0.data, as: UTF8.self)
         }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchDataResponse(url).map { String(decoding: $0.data, as: UTF8.self) }
     }
 
     public func validateCreatureConfig(rawConfig: String) async -> Result<
         CreatureConfigValidationDTO, ServerError
     > {
-        guard let url = URL(string: makeBaseURL(.http) + "/creature/validate") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        logger.debug("Using URL: \(url)")
-
         return await sendRawJson(
-            url, method: "POST", rawJson: rawConfig, returnType: CreatureConfigValidationDTO.self)
+            path: "/creature/validate", method: "POST", rawJson: rawConfig,
+            returnType: CreatureConfigValidationDTO.self)
     }
 
     public func setIdleEnabled(creatureId: CreatureIdentifier, enabled: Bool) async -> Result<
         Creature, ServerError
     > {
-        guard let url = URL(string: makeBaseURL(.http) + "/creature/\(creatureId)/idle") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        logger.debug("Using URL: \(url)")
-
         let requestBody = IdleToggleDTO(enabled: enabled)
         return await sendData(
-            url, method: "PATCH", body: requestBody, returnType: Creature.self)
+            path: "/creature/\(creatureId)/idle", method: "PATCH", body: requestBody,
+            returnType: Creature.self)
     }
 
 }

--- a/Common/Sources/Common/Controller/Server/RESTful/DebugMethods.swift
+++ b/Common/Sources/Common/Controller/Server/RESTful/DebugMethods.swift
@@ -30,16 +30,9 @@ extension CreatureServerClient {
 
         logger.debug("telling the server to send a \(cacheTypeString) cache invalidation message")
 
-        // Construct the URL
-        guard
-            let url = URL(string: makeBaseURL(.http) + "/debug/cache-invalidate/\(cacheTypeString)")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         logger.debug("calling fetchData() now...")
-        let returnObject = await fetchData(url, returnType: StatusDTO.self)
+        let returnObject = await fetchData(
+            path: "/debug/cache-invalidate/\(cacheTypeString)", returnType: StatusDTO.self)
         logger.debug("...and we're back!")
 
         // Yay we got something back
@@ -86,14 +79,8 @@ extension CreatureServerClient {
 
         logger.debug("telling the server to send a fake playlist update command")
 
-        // Construct the URL
-        guard let url = URL(string: makeBaseURL(.http) + "/debug/playlist/update") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         logger.debug("calling fetchData() now...")
-        let returnObject = await fetchData(url, returnType: StatusDTO.self)
+        let returnObject = await fetchData(path: "/debug/playlist/update", returnType: StatusDTO.self)
         logger.debug("...and we're back!")
 
         // Yay we got something back

--- a/Common/Sources/Common/Controller/Server/RESTful/DialogMethods.swift
+++ b/Common/Sources/Common/Controller/Server/RESTful/DialogMethods.swift
@@ -59,12 +59,10 @@ extension CreatureServerClient {
     public func listDialogScripts() async -> Result<[DialogScript], ServerError> {
         logger.debug("attempting to get all of the dialog scripts")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/dialog/script") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: DialogScriptListDTO.self).map { $0.items }
+        return await fetchData(
+            path: "/animation/dialog/script", returnType: DialogScriptListDTO.self
+        )
+        .map { $0.items }
     }
 
     public func getDialogScript(id: DialogScriptIdentifier) async -> Result<
@@ -72,16 +70,9 @@ extension CreatureServerClient {
     > {
         logger.debug("attempting to load dialog script \(id)")
 
-        guard
-            let url = URL(
-                string: makeBaseURL(.http)
-                    + "/animation/dialog/script/\(id.uuidString.lowercased())")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: DialogScript.self)
+        return await fetchData(
+            path: "/animation/dialog/script/\(id.uuidString.lowercased())",
+            returnType: DialogScript.self)
     }
 
     /// Creates a new script. The server stamps `id` + timestamps and returns the full record
@@ -91,14 +82,10 @@ extension CreatureServerClient {
     > {
         logger.debug("attempting to create a new dialog script: \(script.title)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/dialog/script") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         // Send only the editable fields — the server rejects id/created_at/updated_at.
         return await sendData(
-            url, method: "POST", body: UpsertDialogScriptRequest(script),
+            path: "/animation/dialog/script", method: "POST",
+            body: UpsertDialogScriptRequest(script),
             returnType: DialogScript.self)
     }
 
@@ -109,18 +96,10 @@ extension CreatureServerClient {
     > {
         logger.debug("attempting to update dialog script \(script.id)")
 
-        guard
-            let url = URL(
-                string: makeBaseURL(.http)
-                    + "/animation/dialog/script/\(script.id.uuidString.lowercased())")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         // The id travels in the URL path; the body carries only the editable fields.
         return await sendData(
-            url, method: "PUT", body: UpsertDialogScriptRequest(script),
+            path: "/animation/dialog/script/\(script.id.uuidString.lowercased())", method: "PUT",
+            body: UpsertDialogScriptRequest(script),
             returnType: DialogScript.self)
     }
 
@@ -128,17 +107,9 @@ extension CreatureServerClient {
     {
         logger.debug("attempting to delete dialog script \(id)")
 
-        guard
-            let url = URL(
-                string: makeBaseURL(.http)
-                    + "/animation/dialog/script/\(id.uuidString.lowercased())")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         return await sendData(
-            url, method: "DELETE", body: EmptyBody(), returnType: StatusDTO.self
+            path: "/animation/dialog/script/\(id.uuidString.lowercased())", method: "DELETE",
+            body: EmptyBody(), returnType: StatusDTO.self
         ).map { $0.message }
     }
 
@@ -147,15 +118,9 @@ extension CreatureServerClient {
     public func validateDialogScript(_ script: DialogScript) async -> Result<
         DialogScriptValidationDTO, ServerError
     > {
-        guard
-            let url = URL(string: makeBaseURL(.http) + "/animation/dialog/script/validate")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         return await sendData(
-            url, method: "POST", body: script, returnType: DialogScriptValidationDTO.self)
+            path: "/animation/dialog/script/validate", method: "POST", body: script,
+            returnType: DialogScriptValidationDTO.self)
     }
 
     // MARK: - Render
@@ -167,13 +132,9 @@ extension CreatureServerClient {
     > {
         logger.debug("attempting to render a dialog (persistence: \(request.persistence.rawValue))")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/dialog") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         return await sendData(
-            url, method: "POST", body: request, returnType: JobCreatedResponse.self)
+            path: "/animation/dialog", method: "POST", body: request,
+            returnType: JobCreatedResponse.self)
     }
 
     // MARK: - Preview
@@ -191,12 +152,10 @@ extension CreatureServerClient {
     public func dialogPreviewMeta(_ request: DialogPreviewRequest) async -> Result<
         DialogPreviewMetaOutcome, ServerError
     > {
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/dialog/preview/meta") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await sendDataResponse(url, method: "POST", body: request).flatMap { response in
+        return await sendDataResponse(
+            path: "/animation/dialog/preview/meta", method: "POST", body: request
+        )
+        .flatMap { response in
             if response.statusCode == 202 {
                 return decodeResponse(response.data, returnType: JobCreatedResponse.self)
                     .map { .queued($0) }
@@ -211,13 +170,9 @@ extension CreatureServerClient {
     public func dialogPreviewLookup(_ request: DialogPreviewRequest) async -> Result<
         DialogPreviewLookupDTO, ServerError
     > {
-        guard let url = URL(string: makeBaseURL(.http) + "/animation/dialog/preview/lookup") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         return await sendData(
-            url, method: "POST", body: request, returnType: DialogPreviewLookupDTO.self)
+            path: "/animation/dialog/preview/lookup", method: "POST", body: request,
+            returnType: DialogPreviewLookupDTO.self)
     }
 
     /// Fetches the full 17-channel WAV bytes (S16 LE @ 48 kHz, each creature in its
@@ -228,15 +183,9 @@ extension CreatureServerClient {
     public func dialogPreviewMultichannel(_ request: DialogPreviewRequest) async -> Result<
         JobCreatedResponse, ServerError
     > {
-        guard
-            let url = URL(string: makeBaseURL(.http) + "/animation/dialog/preview/multichannel")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         return await sendData(
-            url, method: "POST", body: request, returnType: JobCreatedResponse.self)
+            path: "/animation/dialog/preview/multichannel", method: "POST", body: request,
+            returnType: JobCreatedResponse.self)
     }
 
     /// Downloads the raw bytes at a URL (e.g. the mono preview WAV) using the configured

--- a/Common/Sources/Common/Controller/Server/RESTful/FixtureMethods.swift
+++ b/Common/Sources/Common/Controller/Server/RESTful/FixtureMethods.swift
@@ -8,60 +8,38 @@ extension CreatureServerClient {
     public func getAllFixtures() async -> Result<[DmxFixture], ServerError> {
         logger.debug("attempting to get all of the fixtures")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/fixture") else {
-            return .failure(.serverError("unable to make base URL"))
+        return await fetchData(path: "/fixture", returnType: DmxFixtureListDTO.self).map {
+            $0.items
         }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: DmxFixtureListDTO.self).map { $0.items }
     }
 
     public func getFixture(id: DmxFixtureIdentifier) async -> Result<DmxFixture, ServerError> {
         logger.debug("attempting to load fixture \(id)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/fixture/\(id)") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: DmxFixture.self)
+        return await fetchData(path: "/fixture/\(id)", returnType: DmxFixture.self)
     }
 
     public func upsertFixture(_ fixture: DmxFixture) async -> Result<DmxFixture, ServerError> {
         logger.debug("attempting to upsert fixture \(fixture.id)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/fixture") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         return await sendData(
-            url, method: "POST", body: fixture, returnType: DmxFixture.self)
+            path: "/fixture", method: "POST", body: fixture, returnType: DmxFixture.self)
     }
 
     public func deleteFixture(id: DmxFixtureIdentifier) async -> Result<String, ServerError> {
         logger.debug("attempting to delete fixture \(id)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/fixture/\(id)") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         return await sendData(
-            url, method: "DELETE", body: EmptyBody(), returnType: StatusDTO.self
+            path: "/fixture/\(id)", method: "DELETE", body: EmptyBody(), returnType: StatusDTO.self
         ).map { $0.message }
     }
 
     public func validateFixture(rawJson: String) async -> Result<
         FixtureConfigValidationDTO, ServerError
     > {
-        guard let url = URL(string: makeBaseURL(.http) + "/fixture/validate") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        logger.debug("Using URL: \(url)")
-
         return await sendRawJson(
-            url, method: "POST", rawJson: rawJson, returnType: FixtureConfigValidationDTO.self)
+            path: "/fixture/validate", method: "POST", rawJson: rawJson,
+            returnType: FixtureConfigValidationDTO.self)
     }
 
     /// Returns the updated fixture (server convention — every state-changing fixture
@@ -71,13 +49,9 @@ extension CreatureServerClient {
     > {
         logger.debug("setting universe \(universe) on fixture \(id)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/fixture/\(id)/universe") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let body = SetFixtureUniverseDTO(universe: universe)
-        return await sendData(url, method: "PUT", body: body, returnType: DmxFixture.self)
+        return await sendData(
+            path: "/fixture/\(id)/universe", method: "PUT", body: body, returnType: DmxFixture.self)
     }
 
     public func clearFixtureUniverse(id: DmxFixtureIdentifier) async -> Result<
@@ -85,13 +59,9 @@ extension CreatureServerClient {
     > {
         logger.debug("clearing universe on fixture \(id)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/fixture/\(id)/universe") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         return await sendData(
-            url, method: "DELETE", body: EmptyBody(), returnType: DmxFixture.self)
+            path: "/fixture/\(id)/universe", method: "DELETE", body: EmptyBody(),
+            returnType: DmxFixture.self)
     }
 
     /// Live slider control. `timeoutMs` must be in `(0, 600000]` ms — the server holds
@@ -107,13 +77,9 @@ extension CreatureServerClient {
         logger.debug(
             "live update on fixture \(id): \(values.count) value(s), timeoutMs=\(timeoutMs)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/fixture/\(id)/live") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let body = SetFixtureLiveDTO(values: values, timeoutMs: timeoutMs)
-        return await sendData(url, method: "POST", body: body, returnType: DmxFixture.self)
+        return await sendData(
+            path: "/fixture/\(id)/live", method: "POST", body: body, returnType: DmxFixture.self)
     }
 
     /// Fires an ephemeral pattern constructed from the supplied values + fade timings
@@ -133,13 +99,6 @@ extension CreatureServerClient {
             "previewing pattern on fixture \(fixtureId): \(values.count) value(s), fadeIn=\(fadeInMs) fadeOut=\(fadeOutMs) hold=\(holdMs) stopAfter=\(stopAfterMs.map(String.init) ?? "nil")"
         )
 
-        guard
-            let url = URL(string: makeBaseURL(.http) + "/fixture/\(fixtureId)/pattern/preview")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let body = PreviewFixturePatternDTO(
             values: values,
             fadeInMs: fadeInMs,
@@ -147,7 +106,9 @@ extension CreatureServerClient {
             holdMs: holdMs,
             stopAfterMs: stopAfterMs
         )
-        return await sendData(url, method: "POST", body: body, returnType: DmxFixture.self)
+        return await sendData(
+            path: "/fixture/\(fixtureId)/pattern/preview", method: "POST", body: body,
+            returnType: DmxFixture.self)
     }
 
     public func triggerFixturePattern(
@@ -159,15 +120,9 @@ extension CreatureServerClient {
             "triggering pattern \(patternId) on fixture \(fixtureId), stopAfterMs=\(stopAfterMs.map(String.init) ?? "nil")"
         )
 
-        guard
-            let url = URL(
-                string: makeBaseURL(.http) + "/fixture/\(fixtureId)/pattern/\(patternId)/trigger")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let body = TriggerFixturePatternDTO(stopAfterMs: stopAfterMs)
-        return await sendData(url, method: "POST", body: body, returnType: DmxFixture.self)
+        return await sendData(
+            path: "/fixture/\(fixtureId)/pattern/\(patternId)/trigger", method: "POST", body: body,
+            returnType: DmxFixture.self)
     }
 }

--- a/Common/Sources/Common/Controller/Server/RESTful/JobMethods.swift
+++ b/Common/Sources/Common/Controller/Server/RESTful/JobMethods.swift
@@ -14,14 +14,11 @@ extension CreatureServerClient {
 
         logger.debug("fetching job state for \(jobId)")
 
-        guard let encodedId = urlEncode(jobId),
-            let url = URL(string: makeBaseURL(.http) + "/job/" + encodedId)
-        else {
+        guard let encodedId = urlEncode(jobId) else {
             return .failure(.serverError("unable to make base URL"))
         }
-        self.logger.debug("Using URL: \(url)")
 
-        return await fetchData(url, returnType: JobStateSnapshot.self)
+        return await fetchData(path: "/job/" + encodedId, returnType: JobStateSnapshot.self)
     }
 
 }

--- a/Common/Sources/Common/Controller/Server/RESTful/PlaylistMethods.swift
+++ b/Common/Sources/Common/Controller/Server/RESTful/PlaylistMethods.swift
@@ -12,16 +12,12 @@ extension CreatureServerClient {
     public func stopPlayingPlaylist(universe: UniverseIdentifier) async -> Result<
         String, ServerError
     > {
-        // Construct the URL
-        guard let url = URL(string: makeBaseURL(.http) + "/playlist/stop") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let requestBody = PlaylistStopRequestDTO(universe: universe)
 
-        return await sendData(url, method: "POST", body: requestBody, returnType: StatusDTO.self)
-            .map { $0.message }
+        return await sendData(
+            path: "/playlist/stop", method: "POST", body: requestBody, returnType: StatusDTO.self
+        )
+        .map { $0.message }
     }
 
     public func getPlaylist(playlistId: PlaylistIdentifier) async -> Result<
@@ -38,16 +34,12 @@ extension CreatureServerClient {
 
         logger.debug("attempting start a playlist")
 
-        // Construct the URL
-        guard let url = URL(string: makeBaseURL(.http) + "/playlist/start") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let requestBody = PlaylistRequestDTO(playlist_id: playlistId, universe: universe)
 
-        return await sendData(url, method: "POST", body: requestBody, returnType: StatusDTO.self)
-            .map { $0.message }
+        return await sendData(
+            path: "/playlist/start", method: "POST", body: requestBody, returnType: StatusDTO.self
+        )
+        .map { $0.message }
 
     }
 
@@ -55,12 +47,7 @@ extension CreatureServerClient {
     public func getAllPlaylists() async -> Result<[Playlist], ServerError> {
         logger.debug("attempting to get all the playlists")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/playlist") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: PlaylistListDTO.self).map { $0.items }
+        return await fetchData(path: "/playlist", returnType: PlaylistListDTO.self).map { $0.items }
 
     }
 
@@ -75,13 +62,8 @@ extension CreatureServerClient {
     }
 
     private func upsertPlaylist(_ playlist: Playlist) async -> Result<String, ServerError> {
-        guard let url = URL(string: makeBaseURL(.http) + "/playlist") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let result = await sendDataResponse(
-            url,
+            path: "/playlist",
             method: "POST",
             body: playlist,
             successStatusCodes: [200, 201]
@@ -121,13 +103,11 @@ extension CreatureServerClient {
     > {
         logger.debug("attempting to delete playlist: \(playlistId)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/playlist/\(playlistId)") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await sendData(url, method: "DELETE", body: EmptyBody(), returnType: StatusDTO.self)
-            .map { $0.message }
+        return await sendData(
+            path: "/playlist/\(playlistId)", method: "DELETE", body: EmptyBody(),
+            returnType: StatusDTO.self
+        )
+        .map { $0.message }
     }
 
 }

--- a/Common/Sources/Common/Controller/Server/RESTful/ServerMetricsMethods.swift
+++ b/Common/Sources/Common/Controller/Server/RESTful/ServerMetricsMethods.swift
@@ -14,12 +14,7 @@ extension CreatureServerClient {
 
         logger.debug("trying to get the system metrics from the server")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/metric/counters") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        let result = await fetchData(url, returnType: SystemCountersDTO.self)
+        let result = await fetchData(path: "/metric/counters", returnType: SystemCountersDTO.self)
         if case .success(let counters) = result {
             logger.debug("Got the server's counters, it's on frame \(counters.totalFrames)")
         }

--- a/Common/Sources/Common/Controller/Server/RESTful/SoundMethods.swift
+++ b/Common/Sources/Common/Controller/Server/RESTful/SoundMethods.swift
@@ -44,24 +44,16 @@ extension CreatureServerClient {
 
         logger.debug("attempting to get all of the sounds")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/sound") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: SoundListDTO.self).map { $0.items }
+        return await fetchData(path: "/sound", returnType: SoundListDTO.self).map { $0.items }
     }
 
     public func listAdHocSounds() async -> Result<[AdHocSoundEntry], ServerError> {
 
         logger.debug("attempting to get ad-hoc/generated sounds")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/sound/ad-hoc") else {
-            return .failure(.serverError("unable to make base URL"))
+        return await fetchData(path: "/sound/ad-hoc", returnType: AdHocSoundListDTO.self).map {
+            $0.items
         }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: AdHocSoundListDTO.self).map { $0.items }
     }
 
     /**
@@ -76,16 +68,11 @@ extension CreatureServerClient {
             "attempting to generate lip sync for \(fileName) (allow overwrite: \(allowOverwrite ? "yes" : "no"))"
         )
 
-        guard let url = URL(string: makeBaseURL(.http) + "/sound/generate-lipsync") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let requestBody = GenerateLipSyncRequestDTO(
             soundFile: fileName, allowOverwrite: allowOverwrite)
 
         return await sendData(
-            url,
+            path: "/sound/generate-lipsync",
             method: "POST",
             body: requestBody,
             returnType: JobCreatedResponse.self
@@ -144,19 +131,15 @@ extension CreatureServerClient {
 
         logger.debug("attempting play sound \(fileName) on server")
 
-        // Construct the URL
-        guard let url = URL(string: makeBaseURL(.http) + "/sound/play") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         // No body is needed for this one
         //struct EmptyBody: Encodable {}
 
         let requestBody = PlaySoundRequestDTO(file_name: fileName)
 
-        return await sendData(url, method: "POST", body: requestBody, returnType: StatusDTO.self)
-            .map { $0.message }
+        return await sendData(
+            path: "/sound/play", method: "POST", body: requestBody, returnType: StatusDTO.self
+        )
+        .map { $0.message }
     }
 
     /**
@@ -223,14 +206,12 @@ extension CreatureServerClient {
 
         logger.debug("attempting to fetch provenance for \(fileName)")
 
-        guard let encodedName = urlEncode(soundBasename(fileName)),
-            let url = URL(string: makeBaseURL(.http) + "/sound/provenance/" + encodedName)
-        else {
+        guard let encodedName = urlEncode(soundBasename(fileName)) else {
             return .failure(.serverError("unable to make base URL"))
         }
-        self.logger.debug("Using URL: \(url)")
 
-        return await fetchDataResponse(url).flatMap { response in
+        return await fetchDataResponse(path: "/sound/provenance/" + encodedName).flatMap {
+            response in
             guard let xml = String(data: response.data, encoding: .utf8) else {
                 return .failure(.dataFormatError("provenance response was not valid UTF-8"))
             }
@@ -260,14 +241,11 @@ extension CreatureServerClient {
         logger.debug("attempting to download a shareable version of \(fileName)")
 
         let name = soundBasename(fileName)
-        guard let encodedName = urlEncode(name),
-            let url = URL(string: makeBaseURL(.http) + "/sound/shareable/" + encodedName)
-        else {
+        guard let encodedName = urlEncode(name) else {
             return .failure(.serverError("unable to make base URL"))
         }
-        self.logger.debug("Using URL: \(url)")
 
-        return await fetchDataResponse(url).map { response in
+        return await fetchDataResponse(path: "/sound/shareable/" + encodedName).map { response in
             let fallback: String
             if let dotIndex = name.lastIndex(of: ".") {
                 fallback = String(name[..<dotIndex]) + ".ogg"

--- a/Common/Sources/Common/Controller/Server/RESTful/StoryboardMethods.swift
+++ b/Common/Sources/Common/Controller/Server/RESTful/StoryboardMethods.swift
@@ -8,25 +8,16 @@ extension CreatureServerClient {
     public func listStoryboards() async -> Result<[Storyboard], ServerError> {
         logger.debug("attempting to get all of the storyboards")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/storyboard") else {
-            return .failure(.serverError("unable to make base URL"))
+        return await fetchData(path: "/storyboard", returnType: StoryboardListDTO.self).map {
+            $0.items
         }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: StoryboardListDTO.self).map { $0.items }
     }
 
     public func getStoryboard(id: StoryboardIdentifier) async -> Result<Storyboard, ServerError> {
         logger.debug("attempting to load storyboard \(id)")
 
-        guard
-            let url = URL(string: makeBaseURL(.http) + "/storyboard/\(id.uuidString.lowercased())")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: Storyboard.self)
+        return await fetchData(
+            path: "/storyboard/\(id.uuidString.lowercased())", returnType: Storyboard.self)
     }
 
     /// Creates a new storyboard. The server stamps `id` + timestamps and returns the full record
@@ -35,13 +26,8 @@ extension CreatureServerClient {
     {
         logger.debug("attempting to create a new storyboard: \(storyboard.title)")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/storyboard") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         return await sendData(
-            url, method: "POST", body: UpsertStoryboardRequest(storyboard),
+            path: "/storyboard", method: "POST", body: UpsertStoryboardRequest(storyboard),
             returnType: Storyboard.self)
     }
 
@@ -51,31 +37,18 @@ extension CreatureServerClient {
     {
         logger.debug("attempting to update storyboard \(storyboard.id)")
 
-        guard
-            let url = URL(
-                string: makeBaseURL(.http) + "/storyboard/\(storyboard.id.uuidString.lowercased())")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         return await sendData(
-            url, method: "PUT", body: UpsertStoryboardRequest(storyboard),
+            path: "/storyboard/\(storyboard.id.uuidString.lowercased())", method: "PUT",
+            body: UpsertStoryboardRequest(storyboard),
             returnType: Storyboard.self)
     }
 
     public func deleteStoryboard(id: StoryboardIdentifier) async -> Result<String, ServerError> {
         logger.debug("attempting to delete storyboard \(id)")
 
-        guard
-            let url = URL(string: makeBaseURL(.http) + "/storyboard/\(id.uuidString.lowercased())")
-        else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         return await sendData(
-            url, method: "DELETE", body: EmptyBody(), returnType: StatusDTO.self
+            path: "/storyboard/\(id.uuidString.lowercased())", method: "DELETE", body: EmptyBody(),
+            returnType: StatusDTO.self
         ).map { $0.message }
     }
 }

--- a/Common/Sources/Common/Controller/Server/RESTful/VoiceMethods.swift
+++ b/Common/Sources/Common/Controller/Server/RESTful/VoiceMethods.swift
@@ -11,12 +11,9 @@ extension CreatureServerClient {
 
         logger.debug("attempting to get all of the voices that are available to us")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/voice/list-available") else {
-            return .failure(.serverError("unable to make base URL"))
+        return await fetchData(path: "/voice/list-available", returnType: VoiceListDTO.self).map {
+            $0.items
         }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: VoiceListDTO.self).map { $0.items }
     }
 
     /**
@@ -26,12 +23,8 @@ extension CreatureServerClient {
 
         logger.debug("attempting to get the current state of our elevenlabs.io subscription...")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/voice/subscription") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
-        return await fetchData(url, returnType: VoiceSubscriptionStatus.self)
+        return await fetchData(
+            path: "/voice/subscription", returnType: VoiceSubscriptionStatus.self)
     }
 
     /**
@@ -46,15 +39,10 @@ extension CreatureServerClient {
 
         logger.debug("asking the server to request a new creature speech sound file")
 
-        guard let url = URL(string: makeBaseURL(.http) + "/voice") else {
-            return .failure(.serverError("unable to make base URL"))
-        }
-        self.logger.debug("Using URL: \(url)")
-
         let requestBody = MakeSoundFileRequestDTO(creature_id: creatureId, title: title, text: text)
 
         return await sendData(
-            url, method: "POST", body: requestBody, returnType: JobCreatedResponse.self)
+            path: "/voice", method: "POST", body: requestBody, returnType: JobCreatedResponse.self)
     }
 
 

--- a/Common/Sources/CreatureAgent/top.swift
+++ b/Common/Sources/CreatureAgent/top.swift
@@ -32,7 +32,7 @@ struct CreatureAgent: AsyncParsableCommand {
         abstract: "Listen to MQTT, generate LLM responses, schedule ad-hoc speech",
         discussion:
             "Consumes MQTT topics and uses an LLM backend (OpenAI or local) to generate ad-hoc speech animations on the Creature server.",
-        version: "2.28.1",
+        version: "2.34.6",
         subcommands: [Run.self],
         defaultSubcommand: Run.self,
         helpNames: .shortAndLong

--- a/Common/Sources/CreatureCLI/top.swift
+++ b/Common/Sources/CreatureCLI/top.swift
@@ -35,7 +35,7 @@ struct CreatureCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for interacting with the Creature Server",
         discussion: "A tool for interacting and testing the Creature Server from the command line",
-        version: "2.34.5",
+        version: "2.34.6",
         subcommands: [
             Animations.self, Creatures.self, Debug.self, Dialog.self, Fixtures.self, Metrics.self,
             Network.self, Playlists.self, Sounds.self, Storyboards.self, Util.self, Voice.self,

--- a/Common/Sources/CreatureMQTT/top.swift
+++ b/Common/Sources/CreatureMQTT/top.swift
@@ -76,7 +76,7 @@ struct CreatureMQTT: AsyncParsableCommand {
         abstract: "Bridge Creature websocket events into MQTT",
         discussion:
             "Subscribes to the Creature websocket API and republishes incoming messages to an MQTT broker for Home Assistant.",
-        version: "2.28.1",
+        version: "2.34.6",
         subcommands: [Bridge.self],
         defaultSubcommand: Bridge.self,
         helpNames: .shortAndLong

--- a/Creature Console.xcodeproj/project.pbxproj
+++ b/Creature Console.xcodeproj/project.pbxproj
@@ -2045,7 +2045,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.34.5;
+				MARKETING_VERSION = 2.34.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -2099,7 +2099,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.34.5;
+				MARKETING_VERSION = 2.34.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2183,7 +2183,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.34.5;
+				MARKETING_VERSION = 2.34.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -2215,7 +2215,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.34.5;
+				MARKETING_VERSION = 2.34.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+creature-cli (2.34.6) unstable; urgency=medium
+
+  * Internal refactor (no behavior change): the ~50 REST methods that each
+    hand-rolled the same `guard let url = URL(string: makeBaseURL(.http) + path)`
+    boilerplate now call `path:` overloads on the client that own URL building,
+    the guard, and the debug log. Net ~210 fewer lines (DRY audit, issue #8).
+
+ -- April White <april@creature.engineering>  Fri, 03 Jul 2026 00:00:00 +0000
+
 creature-cli (2.34.5) unstable; urgency=medium
 
   * Internal refactor (no behavior change): the duplicated `formatMillis` date

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,9 @@ creature-cli (2.34.6) unstable; urgency=medium
     hand-rolled the same `guard let url = URL(string: makeBaseURL(.http) + path)`
     boilerplate now call `path:` overloads on the client that own URL building,
     the guard, and the debug log. Net ~210 fewer lines (DRY audit, issue #8).
+  * Version sync: creature-mqtt and creature-agent are bumped to 2.34.6 to match
+    creature-cli (their `--version` had drifted, still reporting 2.28.1). No
+    functional change in those two tools.
 
  -- April White <april@creature.engineering>  Fri, 03 Jul 2026 00:00:00 +0000
 


### PR DESCRIPTION
The largest DRY finding (#4): ~50 REST methods each hand-rolled the identical
```swift
guard let url = URL(string: makeBaseURL(.http) + "<path>") else {
    return .failure(.serverError("unable to make base URL"))
}
logger.debug("Using URL: \(url)")
return await fetchData(url, ...)
```

## What changed
- Added `path:` overloads on `CreatureServerClient` — `fetchData`, `fetchDataResponse`, `sendData`, `sendDataResponse`, `sendRawJson` — plus a `makeURL(_:)` helper. They own URL building, the guard, and the debug log.
- Every standard call site across the **11 RESTful method files** now passes `path:`. No behavior change — same routes, same requests, same failure.
- **Net −202 lines.**

## Deliberately left as-is
- URL-*returning* builders: `getSoundURL`/`getAdHocSoundURL`/`getShareableSoundURL`, the dialog preview-URL builders, `makeAbsoluteURL`.
- `generateLipSyncUpload` (uses `sendBinaryDataResponse`, which has no `path:` overload).
- The WebSocket URL (`.websocket` base).

## Verification
- Builds clean on **macOS, iOS, and `creature-cli`**.
- `Common` test suite: 342 passing.
- **Linux**: all three products (`creature-cli`, `creature-mqtt`, `creature-agent`) build in the `swift:6.3.2` container.
- Reviewed every migrated `path:` string — all match the documented routes.

_Migration fanned out one agent per file; I added the `path:` overloads and the one fused-guard case (`JobMethods.getJob`) by hand, then verified the whole thing._

Refs #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)