### PR TITLE
DRY #8 (final): watchJob modifier + rebuildAfterDialogRender — closes #8

### DIFF
--- a/Common/Sources/CreatureAgent/top.swift
+++ b/Common/Sources/CreatureAgent/top.swift
@@ -32,7 +32,7 @@ struct CreatureAgent: AsyncParsableCommand {
         abstract: "Listen to MQTT, generate LLM responses, schedule ad-hoc speech",
         discussion:
             "Consumes MQTT topics and uses an LLM backend (OpenAI or local) to generate ad-hoc speech animations on the Creature server.",
-        version: "2.34.6",
+        version: "2.34.7",
         subcommands: [Run.self],
         defaultSubcommand: Run.self,
         helpNames: .shortAndLong

--- a/Common/Sources/CreatureCLI/top.swift
+++ b/Common/Sources/CreatureCLI/top.swift
@@ -35,7 +35,7 @@ struct CreatureCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for interacting with the Creature Server",
         discussion: "A tool for interacting and testing the Creature Server from the command line",
-        version: "2.34.6",
+        version: "2.34.7",
         subcommands: [
             Animations.self, Creatures.self, Debug.self, Dialog.self, Fixtures.self, Metrics.self,
             Network.self, Playlists.self, Sounds.self, Storyboards.self, Util.self, Voice.self,

--- a/Common/Sources/CreatureMQTT/top.swift
+++ b/Common/Sources/CreatureMQTT/top.swift
@@ -76,7 +76,7 @@ struct CreatureMQTT: AsyncParsableCommand {
         abstract: "Bridge Creature websocket events into MQTT",
         discussion:
             "Subscribes to the Creature websocket API and republishes incoming messages to an MQTT broker for Home Assistant.",
-        version: "2.34.6",
+        version: "2.34.7",
         subcommands: [Bridge.self],
         defaultSubcommand: Bridge.self,
         helpNames: .shortAndLong

--- a/Creature Console.xcodeproj/project.pbxproj
+++ b/Creature Console.xcodeproj/project.pbxproj
@@ -168,6 +168,8 @@
 		11B0488E2EB8430E001B73C5 /* ProcessingOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B0488B2EB8430E001B73C5 /* ProcessingOverlayView.swift */; };
 		FEA1A1E70000000000000002 /* ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA1A1E70000000000000001 /* ErrorAlert.swift */; };
 		FEA1A1E70000000000000003 /* ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA1A1E70000000000000001 /* ErrorAlert.swift */; };
+		FEA1A1E70000000000000005 /* JobWatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA1A1E70000000000000004 /* JobWatching.swift */; };
+		FEA1A1E70000000000000006 /* JobWatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA1A1E70000000000000004 /* JobWatching.swift */; };
 		11BC3BAC2E98B4E5002A568C /* SimpleKeychain in Frameworks */ = {isa = PBXBuildFile; productRef = 11BC3BAB2E98B4E5002A568C /* SimpleKeychain */; };
 		11BC3C3A2A0DF62300410F63 /* AudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BC3C392A0DF62300410F63 /* AudioManager.swift */; };
 		11BF13972E42D32E00728799 /* CreatePlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BF13952E42D32E00728799 /* CreatePlaylistView.swift */; };
@@ -396,6 +398,7 @@
 		11B048872EB842B3001B73C5 /* LipSyncUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LipSyncUtilities.swift; sourceTree = "<group>"; };
 		11B0488B2EB8430E001B73C5 /* ProcessingOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessingOverlayView.swift; sourceTree = "<group>"; };
 		FEA1A1E70000000000000001 /* ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlert.swift; sourceTree = "<group>"; };
+		FEA1A1E70000000000000004 /* JobWatching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobWatching.swift; sourceTree = "<group>"; };
 		11B9F1A72A0DDC5800F6C00A /* Creature_Console.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Creature_Console.entitlements; sourceTree = "<group>"; };
 		11BC3C392A0DF62300410F63 /* AudioManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManager.swift; sourceTree = "<group>"; };
 		11BF13952E42D32E00728799 /* CreatePlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePlaylistView.swift; sourceTree = "<group>"; };
@@ -1057,6 +1060,7 @@
 			children = (
 				11B0488B2EB8430E001B73C5 /* ProcessingOverlayView.swift */,
 				FEA1A1E70000000000000001 /* ErrorAlert.swift */,
+				FEA1A1E70000000000000004 /* JobWatching.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1683,6 +1687,7 @@
 				1199D6BF2BF5C4EA004E0D64 /* ServerLogItemProcessor.swift in Sources */,
 				11B0488D2EB8430E001B73C5 /* ProcessingOverlayView.swift in Sources */,
 				FEA1A1E70000000000000002 /* ErrorAlert.swift in Sources */,
+				FEA1A1E70000000000000005 /* JobWatching.swift in Sources */,
 				11AFC3192BE9ED7700602604 /* CreatureManager.swift in Sources */,
 				1142E66229DFB22300B795F0 /* CreatureDetail.swift in Sources */,
 				11703D8C29DD197F00EF7E3D /* CreatureConsole.swift in Sources */,
@@ -1779,6 +1784,7 @@
 				11E53CD02E88A0C400C17F16 /* AppBootstrapper.swift in Sources */,
 				11B0488E2EB8430E001B73C5 /* ProcessingOverlayView.swift in Sources */,
 				FEA1A1E70000000000000003 /* ErrorAlert.swift in Sources */,
+				FEA1A1E70000000000000006 /* JobWatching.swift in Sources */,
 				117C876F2CA0D45E007B5682 /* BottomToolBarView.swift in Sources */,
 				117C87702CA0D586007B5682 /* NetworkSettingsView.swift in Sources */,
 				11C7F0AA2F2A6D2C009A1B2C /* HideBottomToolbarPreferenceKey.swift in Sources */,
@@ -2045,7 +2051,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.34.6;
+				MARKETING_VERSION = 2.34.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -2099,7 +2105,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.34.6;
+				MARKETING_VERSION = 2.34.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-Console";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2183,7 +2189,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.34.6;
+				MARKETING_VERSION = 2.34.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -2215,7 +2221,7 @@
 					"@executable_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.34.6;
+				MARKETING_VERSION = 2.34.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.opsnlops.Creature-TV";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;

--- a/Sources/Creature Console/Controller/Server/CacheInvalidationProcessor.swift
+++ b/Sources/Creature Console/Controller/Server/CacheInvalidationProcessor.swift
@@ -253,6 +253,14 @@ struct CacheInvalidationProcessor {
         }
     }
 
+    /// A permanent dialog render writes to both the animation and sound collections, so the
+    /// render + re-render surfaces refresh both once the job completes (rather than waiting on
+    /// the websocket invalidation). One call so those sites don't drift apart.
+    static func rebuildAfterDialogRender() {
+        rebuildAnimationCache(deleteStaleEntries: true)
+        rebuildSoundListCache(deleteStaleEntries: true)
+    }
+
 
     // Async version that can be awaited for sequential execution
     private static func rebuildFixtureCacheAsync(deleteStaleEntries: Bool = false) async {

--- a/Sources/Creature Console/View/Animation/AnimationTable.swift
+++ b/Sources/Creature Console/View/Animation/AnimationTable.swift
@@ -47,7 +47,6 @@ struct AnimationTable: View {
     @State private var activeAnimationLipSyncJob:
         (animationId: AnimationIdentifier, jobId: String)? = nil
     @State private var observedJobInfo: JobStatusStore.JobInfo? = nil
-    @State private var jobEventsTask: Task<Void, Never>? = nil
     @State private var pendingDeleteAnimation: AnimationIdentifier? = nil
     @State private var showDeleteConfirmation = false
     @State private var deleteAnimationTask: Task<Void, Never>? = nil
@@ -225,13 +224,11 @@ struct AnimationTable: View {
                 playAnimationTask?.cancel()
                 interruptAnimationTask?.cancel()
                 generateLipSyncTask?.cancel()
-                jobEventsTask?.cancel()
                 deleteAnimationTask?.cancel()
                 renameAnimationTask?.cancel()
                 loadScriptTask?.cancel()
                 loadScriptTask = nil
                 generateLipSyncTask = nil
-                jobEventsTask = nil
                 deleteAnimationTask = nil
                 renameAnimationTask = nil
                 filmingFlowTask?.cancel()
@@ -355,29 +352,17 @@ struct AnimationTable: View {
                 value: activeAnimationLipSyncJob != nil || generatingLipSyncForAnimation != nil
                     || isDeletingAnimation || isRenamingAnimation
             )
-            .task(id: activeAnimationLipSyncJob?.jobId) {
-                jobEventsTask?.cancel()
-                observedJobInfo = nil
-
-                guard let job = activeAnimationLipSyncJob else { return }
-                jobEventsTask = Task {
-                    for await event in await JobStatusStore.shared.events(forJob: job.jobId) {
-                        switch event {
-                        case .updated(let info):
-                            await MainActor.run { observedJobInfo = info }
-                        case .terminal(let info):
-                            await MainActor.run {
-                                observedJobInfo = info
-                                handleAnimationJobCompletion(
-                                    info: info, animationId: job.animationId)
-                            }
-                        case .removed:
-                            await MainActor.run {
-                                finalizeAnimationJob()
-                            }
-                        }
-                    }
+            .watchJob(activeAnimationLipSyncJob?.jobId) { info in
+                observedJobInfo = info
+            } onTerminal: { info in
+                observedJobInfo = info
+                if let animationId = activeAnimationLipSyncJob?.animationId {
+                    handleAnimationJobCompletion(info: info, animationId: animationId)
+                } else {
+                    finalizeAnimationJob()
                 }
+            } onRemoved: {
+                finalizeAnimationJob()
             }
         }  // NavigationStack
     }  // body
@@ -701,7 +686,6 @@ struct AnimationTable: View {
         generatingLipSyncForAnimation = nil
         activeAnimationLipSyncJob = nil
         observedJobInfo = nil
-        jobEventsTask = nil
     }
 
     func loadAnimationForEditing(animationId: AnimationIdentifier) {

--- a/Sources/Creature Console/View/Dialog/DialogRenderPanel.swift
+++ b/Sources/Creature Console/View/Dialog/DialogRenderPanel.swift
@@ -29,7 +29,6 @@ struct DialogRenderPanel: View {
 
     @State private var activeJobId: String? = nil
     @State private var observedJob: JobStatusStore.JobInfo? = nil
-    @State private var jobEventsTask: Task<Void, Never>? = nil
     @State private var isSubmitting = false
 
     @State private var completedResult: DialogJobResult? = nil
@@ -109,28 +108,12 @@ struct DialogRenderPanel: View {
         }
         .shareableSoundFlow(fileName: $renderedSoundToShare)
         .errorAlert($errorAlert)
-        .task(id: activeJobId) {
-            jobEventsTask?.cancel()
-            guard let jobId = activeJobId else { return }
-            jobEventsTask = Task {
-                for await event in await JobStatusStore.shared.events(forJob: jobId) {
-                    switch event {
-                    case .updated(let info):
-                        await MainActor.run { observedJob = info }
-                    case .terminal(let info):
-                        await MainActor.run {
-                            observedJob = info
-                            handleTerminal(info)
-                        }
-                    case .removed:
-                        break
-                    }
-                }
-            }
-        }
-        .onDisappear {
-            jobEventsTask?.cancel()
-            jobEventsTask = nil
+        .watchJob(activeJobId) { info in
+            observedJob = info
+        } onTerminal: { info in
+            observedJob = info
+            handleTerminal(info)
+        } onRemoved: {
         }
     }
 
@@ -220,10 +203,7 @@ struct DialogRenderPanel: View {
         switch info.status {
         case .completed:
             completedResult = info.dialogResult
-            // A permanent render writes to the main animation + sound collections; refresh both
-            // so the new animation shows up without waiting on the websocket invalidation.
-            CacheInvalidationProcessor.rebuildAnimationCache(deleteStaleEntries: true)
-            CacheInvalidationProcessor.rebuildSoundListCache(deleteStaleEntries: true)
+            CacheInvalidationProcessor.rebuildAfterDialogRender()
         case .failed:
             errorAlert = ErrorAlert(
                 title: "Render Error",

--- a/Sources/Creature Console/View/Dialog/DialogRerenderButton.swift
+++ b/Sources/Creature Console/View/Dialog/DialogRerenderButton.swift
@@ -27,7 +27,6 @@ struct DialogRerenderButton: View {
 
     @State private var jobId: String? = nil
     @State private var progress: Double? = nil
-    @State private var jobTask: Task<Void, Never>? = nil
     @State private var isRendering = false
     @State private var successMessage: String? = nil
     @State private var errorMessage: String? = nil
@@ -76,25 +75,11 @@ struct DialogRerenderButton: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .glassEffect(.regular, in: .rect(cornerRadius: 12))
-        .task(id: jobId) {
-            jobTask?.cancel()
-            guard let jobId else { return }
-            jobTask = Task {
-                for await event in await JobStatusStore.shared.events(forJob: jobId) {
-                    switch event {
-                    case .updated(let info):
-                        await MainActor.run { progress = info.progress }
-                    case .terminal(let info):
-                        await MainActor.run { handleTerminal(info) }
-                    case .removed:
-                        break
-                    }
-                }
-            }
-        }
-        .onDisappear {
-            jobTask?.cancel()
-            jobTask = nil
+        .watchJob(jobId) { info in
+            progress = info.progress
+        } onTerminal: { info in
+            handleTerminal(info)
+        } onRemoved: {
         }
     }
 
@@ -130,8 +115,7 @@ struct DialogRerenderButton: View {
         switch info.status {
         case .completed:
             successMessage = "Re-rendered in place — same animation ID, updated audio & tracks."
-            CacheInvalidationProcessor.rebuildAnimationCache(deleteStaleEntries: true)
-            CacheInvalidationProcessor.rebuildSoundListCache(deleteStaleEntries: true)
+            CacheInvalidationProcessor.rebuildAfterDialogRender()
             if let result = info.dialogResult {
                 onCompleted?(result)
             }

--- a/Sources/Creature Console/View/Shared/JobWatching.swift
+++ b/Sources/Creature Console/View/Shared/JobWatching.swift
@@ -1,0 +1,32 @@
+import Common
+import SwiftUI
+
+extension View {
+    /// Observes a single job's lifecycle via `JobStatusStore.events(forJob:)`, re-subscribing
+    /// whenever `jobId` changes and delivering each event to the callbacks on the MainActor.
+    ///
+    /// This replaces the hand-rolled `.task(id:) { … for await event in events(forJob:) {
+    /// switch … } }` block (plus its manual observing-`Task` and `.onDisappear` cancel) that
+    /// every job panel copied. `.task(id:)` owns cancellation — on `jobId` change and on
+    /// disappear — so callers no longer track the observing task themselves (issue #8, #7).
+    ///
+    /// The `.task` operation runs off the MainActor, so each callback is hopped onto it, matching
+    /// the per-site `await MainActor.run { … }` the call sites used to write by hand.
+    func watchJob(
+        _ jobId: String?,
+        onUpdate: @escaping @MainActor (JobStatusStore.JobInfo) -> Void = { _ in },
+        onTerminal: @escaping @MainActor (JobStatusStore.JobInfo) -> Void,
+        onRemoved: @escaping @MainActor () -> Void
+    ) -> some View {
+        task(id: jobId) {
+            guard let jobId else { return }
+            for await event in await JobStatusStore.shared.events(forJob: jobId) {
+                switch event {
+                case .updated(let info): await MainActor.run { onUpdate(info) }
+                case .terminal(let info): await MainActor.run { onTerminal(info) }
+                case .removed: await MainActor.run { onRemoved() }
+                }
+            }
+        }
+    }
+}

--- a/Sources/Creature Console/View/Sounds/SoundFileListView.swift
+++ b/Sources/Creature Console/View/Sounds/SoundFileListView.swift
@@ -29,7 +29,6 @@ struct SoundFileListView: View {
     @State private var pendingRegenerateSound: SoundIdentifier? = nil
     @State private var showRegenerateConfirmation = false
     @State private var observedJobInfo: JobStatusStore.JobInfo?
-    @State private var jobEventsTask: Task<Void, Never>?
     @State private var soundToShare: String? = nil
     @State private var identifiedProvenance: IdentifiedProvenance? = nil
     @State private var loadingProvenanceFor: String? = nil
@@ -185,32 +184,13 @@ struct SoundFileListView: View {
                 }
             }
             .animation(.default, value: generatingLipSyncFor != nil || preparingFile != nil)
-            .task(id: activeLipSyncJob?.jobId) {
-                jobEventsTask?.cancel()
-                observedJobInfo = nil
-
-                guard let job = activeLipSyncJob else { return }
-                jobEventsTask = Task {
-                    for await event in await JobStatusStore.shared.events(forJob: job.jobId) {
-                        switch event {
-                        case .updated(let info):
-                            await MainActor.run { observedJobInfo = info }
-                        case .terminal(let info):
-                            await MainActor.run {
-                                observedJobInfo = info
-                                handleJobCompletion(info: info, soundId: job.soundId)
-                            }
-                        case .removed:
-                            await MainActor.run {
-                                finalizeActiveJob()
-                            }
-                        }
-                    }
-                }
-            }
-            .onDisappear {
-                jobEventsTask?.cancel()
-                jobEventsTask = nil
+            .watchJob(activeLipSyncJob?.jobId) { info in
+                observedJobInfo = info
+            } onTerminal: { info in
+                observedJobInfo = info
+                handleJobCompletion(info: info, soundId: activeLipSyncJob?.soundId ?? "")
+            } onRemoved: {
+                finalizeActiveJob()
             }
             .confirmationDialog(
                 "Regenerate Lip Sync?",
@@ -319,7 +299,6 @@ struct SoundFileListView: View {
         generatingLipSyncFor = nil
         activeLipSyncJob = nil
         observedJobInfo = nil
-        jobEventsTask = nil
     }
 
     private func startLipSyncGeneration(

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+creature-cli (2.34.7) unstable; urgency=medium
+
+  * No CLI changes — version bump to stay in lockstep with the Console app,
+    which finishes the DRY audit (issue #8): a shared `.watchJob(_:onUpdate:
+    onTerminal:onRemoved:)` view modifier replaces the copy-pasted job-observation
+    dispatch in four views, and a `rebuildAfterDialogRender()` helper replaces the
+    animation+sound cache-rebuild pair at the two dialog-render sites.
+
+ -- April White <april@creature.engineering>  Fri, 03 Jul 2026 00:00:00 +0000
+
 creature-cli (2.34.6) unstable; urgency=medium
 
   * Internal refactor (no behavior change): the ~50 REST methods that each


### PR DESCRIPTION
The last two findings on the DRY audit (#8).

## #8 — cache-rebuild pair
The two dialog-render sites (`DialogRenderPanel`, `DialogRerenderButton`) each called `rebuildAnimationCache(...)` + `rebuildSoundListCache(...)` on completion. Now one `CacheInvalidationProcessor.rebuildAfterDialogRender()`.

## #7 — parallel job-observation dispatch
Finding #1 already shared the `events(forJob:)` *stream*, but four views still copy-pasted the same dispatch scaffold:
```swift
.task(id: jobId) {
    task?.cancel()
    for await event in events(forJob:) { switch { .updated / .terminal / .removed } }
}
.onDisappear { task?.cancel() }
```
New **`.watchJob(_:onUpdate:onTerminal:onRemoved:)`** view modifier (`View/Shared/JobWatching.swift`) owns the subscribe / dispatch / MainActor-hop / cancellation (via `.task(id:)`, so the manual observing `Task` and `onDisappear` are gone). Migrated **SoundFileListView, AnimationTable, DialogRenderPanel, DialogRerenderButton**.

Deliberately **not** migrated: `DialogPreviewPanel` and `CreateNewCreatureSoundView` consume `events(forJob:)` *inline* — they `await` the terminal result as a return value in an async computation, which the reactive modifier doesn't model. Correct to leave them.

## Notes
- **App-target only** — no Common change (so no Linux/CLI build needed). Builds clean on **macOS, iOS, tvOS**.
- Registered `JobWatching.swift` in both app targets (`pbxproj`, lint-checked).
- Version synced across **all three CLI tools** per the lockstep policy.
- Net reduction in the migrated views (~−60 lines) even after adding the modifier.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)